### PR TITLE
DELETE's params should follow GET

### DIFF
--- a/sigopt/v1/interface.py
+++ b/sigopt/v1/interface.py
@@ -105,7 +105,7 @@ class Connection(BaseConnection):
     request_params = self._to_api_value(params)
     return self._handle_response(requests.delete(
       url,
-      json=request_params,
+      params=request_params,
       auth=self.client_auth,
       headers=self.default_headers,
     ))


### PR DESCRIPTION
Some clients may strip body of delete request, url params is a safer way to pass params.
In addition, resource identified by GET uri may be deleted with DELETE uri (if implemented)