### PR TITLE
More helpful error message for attribute-error

### DIFF
--- a/sigopt/resource.py
+++ b/sigopt/resource.py
@@ -21,7 +21,14 @@ class BoundApiResource(object):
       sub_resource = self._resource._sub_resources.get(attr)
       if sub_resource:
         return PartiallyBoundApiResource(sub_resource, self)
-    raise AttributeError(attr)
+    raise AttributeError(
+      'Cannot find attribute `{attribute}` on resource `{resource}`, likely no endpoint exists for: '
+      '{base_url}/{attribute}, or `{resource}` does not support `{attribute}`.'.format(
+        attribute=attr,
+        resource=self._resource._name,
+        base_url=self._base_url,
+      )
+    )
 
 class PartiallyBoundApiResource(object):
   def __init__(self, resource, bound_parent_resource):


### PR DESCRIPTION
Dancing a little bit between helpful error for v1 or for v0. If conn is a `v1` connection, these are possible error messages the user could see if they misspell, or are attempting to request a `v0` endpoint.

```
conn.experiments(1715).fetc()
AttributeError: Cannot find attribute `fetc` on resource `experiments`, likely no endpoint exists for: https://api.sigopt.com/v1/experiments/1715/fetc, or `experiments` does not support `fetc`.
```

```
conn.experiments(1715).history()
AttributeError: Cannot find attribute `history` on resource `experiments`, likely no endpoint exists for: https://api.sigopt.com/v1/experiments/1715/history, or `experiments` does not support `history`.
```