### PR TITLE
cc @pfhayes, bumping to 1.2.1, because the env variable is 'add[ing] …

### DIFF
--- a/sigopt/version.py
+++ b/sigopt/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.1.1'
+VERSION = '1.2.1'


### PR DESCRIPTION
…functionality in a backwards-compatible manner'