### PR TITLE
allow changing the user_agent header

### DIFF
--- a/sigopt/interface.py
+++ b/sigopt/interface.py
@@ -147,14 +147,15 @@ class Connection(object):
   Client-facing interface for creating Connections.
   Shouldn't be changed without a major version change.
   """
-  def __init__(self, client_token=None):
+  def __init__(self, client_token=None, user_agent=None):
     client_token = client_token or os.environ.get('SIGOPT_API_TOKEN')
     if not client_token:
       raise ValueError('Must provide client_token or set environment variable SIGOPT_API_TOKEN')
 
     default_headers = {
       'Content-Type': 'application/json',
-      'User-Agent': 'sigopt-python/{0}'.format(VERSION),
+      'User-Agent': user_agent if user_agent is not None else 'sigopt-python/{0}'.format(VERSION),
+      'X-SigOpt-Python-Version': VERSION,
     }
     requestor = Requestor(client_token, '', default_headers)
     self.impl = ConnectionImpl(requestor)

--- a/sigopt/version.py
+++ b/sigopt/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.3.0'
+VERSION = '2.4.0'


### PR DESCRIPTION
cc @pfhayes Allow custom user agents, useful for things like scikit-learn integration. Always tag the sigopt-python version in headers.