### PR TITLE
Remove support for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"


### PR DESCRIPTION
Reached EOL, not supported by travis

@alexandraj777