### PR TITLE
Deprecate metric field in the Experiment object

### DIFF
--- a/sigopt/objects.py
+++ b/sigopt/objects.py
@@ -307,7 +307,10 @@ class Experiment(ApiObject):
   id = Field(six.text_type)
   max_checkpoints = Field(int)
   metadata = Field(Metadata)
-  metric = DeprecatedField(Metric, recommendation='Prefer the `metrics` field (see https://sigopt.com/docs/objects/experiment)')
+  metric = DeprecatedField(
+    Metric,
+    recommendation='Prefer the `metrics` field (see https://sigopt.com/docs/objects/experiment)'
+  )
   metrics = Field(ListOf(Metric))
   name = Field(six.text_type)
   num_solutions = Field(int)

--- a/sigopt/objects.py
+++ b/sigopt/objects.py
@@ -307,7 +307,7 @@ class Experiment(ApiObject):
   id = Field(six.text_type)
   max_checkpoints = Field(int)
   metadata = Field(Metadata)
-  metric = DeprecatedField(Metric, recommendation='Prefer the first item of the `metrics` field')
+  metric = DeprecatedField(Metric, recommendation='Prefer the `metrics` field (see https://sigopt.com/docs/objects/experiment)')
   metrics = Field(ListOf(Metric))
   name = Field(six.text_type)
   num_solutions = Field(int)

--- a/sigopt/objects.py
+++ b/sigopt/objects.py
@@ -307,7 +307,6 @@ class Experiment(ApiObject):
   id = Field(six.text_type)
   max_checkpoints = Field(int)
   metadata = Field(Metadata)
-  metric = Field(Metric)
   metrics = Field(ListOf(Metric))
   name = Field(six.text_type)
   num_solutions = Field(int)

--- a/sigopt/objects.py
+++ b/sigopt/objects.py
@@ -307,6 +307,7 @@ class Experiment(ApiObject):
   id = Field(six.text_type)
   max_checkpoints = Field(int)
   metadata = Field(Metadata)
+  metric = DeprecatedField(Metric, recommendation='Prefer the first item of the `metrics` field'))
   metrics = Field(ListOf(Metric))
   name = Field(six.text_type)
   num_solutions = Field(int)

--- a/sigopt/objects.py
+++ b/sigopt/objects.py
@@ -307,7 +307,7 @@ class Experiment(ApiObject):
   id = Field(six.text_type)
   max_checkpoints = Field(int)
   metadata = Field(Metadata)
-  metric = DeprecatedField(Metric, recommendation='Prefer the first item of the `metrics` field'))
+  metric = DeprecatedField(Metric, recommendation='Prefer the first item of the `metrics` field')
   metrics = Field(ListOf(Metric))
   name = Field(six.text_type)
   num_solutions = Field(int)


### PR DESCRIPTION
This field is not in the docs anymore. By request from @startakovsky. 