### PR TITLE
expose experiment fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+.pytest_cache/
 build/
 dist/
 *.egg-info/

--- a/sigopt/objects.py
+++ b/sigopt/objects.py
@@ -309,11 +309,11 @@ class Experiment(ApiObject):
   can_be_deleted = DeprecatedField(bool)
   client = Field(six.text_type)
   conditionals = Field(ListOf(Conditional))
-  linear_constraints = Field(ListOf(LinearConstraint))
   created = Field(int)
   development = Field(bool)
   folds = Field(int)
   id = Field(six.text_type)
+  linear_constraints = Field(ListOf(LinearConstraint))
   max_checkpoints = Field(int)
   metadata = Field(Metadata)
   metric = DeprecatedField(

--- a/sigopt/objects.py
+++ b/sigopt/objects.py
@@ -330,7 +330,7 @@ class Experiment(ApiObject):
   state = Field(six.text_type)
   type = Field(six.text_type)
   updated = Field(int)
-  user = Field(int)
+  user = Field(six.text_type)
 
 
 class Token(ApiObject):

--- a/sigopt/objects.py
+++ b/sigopt/objects.py
@@ -329,6 +329,8 @@ class Experiment(ApiObject):
   progress = Field(Progress)
   state = Field(six.text_type)
   type = Field(six.text_type)
+  updated = Field(int)
+  user = Field(int)
 
 
 class Token(ApiObject):

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -39,5 +39,6 @@ class TestInterface(object):
     assert conn.impl.requestor.proxies['http'] == 'http://127.0.0.1:6543'
 
   def test_error(self):
-    with pytest.raises(ValueError):
-      Connection()
+    with mock.patch.dict(os.environ, {'SIGOPT_API_TOKEN': ''}):
+      with pytest.raises(ValueError):
+        Connection()

--- a/test/test_object.py
+++ b/test/test_object.py
@@ -229,7 +229,7 @@ class TestObjects(object):
         'ghi': 123,
       },
       'updated': 453,
-      'user': 789,
+      'user': '789',
     })
 
   def test_experiment(self, experiment):
@@ -336,7 +336,7 @@ class TestObjects(object):
     assert experiment.max_checkpoints == 9
     assert experiment.parallel_bandwidth == 2
     assert experiment.updated == 453
-    assert experiment.user == 789
+    assert experiment.user == '789'
 
     with warnings.catch_warnings(record=True) as w:
       assert experiment.can_be_deleted is None

--- a/test/test_object.py
+++ b/test/test_object.py
@@ -228,6 +228,8 @@ class TestObjects(object):
         'abc': 'def',
         'ghi': 123,
       },
+      'updated': 453,
+      'user': 789,
     })
 
   def test_experiment(self, experiment):
@@ -333,6 +335,8 @@ class TestObjects(object):
     assert experiment.folds == 10
     assert experiment.max_checkpoints == 9
     assert experiment.parallel_bandwidth == 2
+    assert experiment.updated == 453
+    assert experiment.user == 789
 
     with warnings.catch_warnings(record=True) as w:
       assert experiment.can_be_deleted is None


### PR DESCRIPTION
added `updated` and `user` fields to `experiment` object, as requested on [asana ticket](https://app.asana.com/0/160711400613812/555133661704417).

Noticed a few other things; I can break into separate PRs if desired.