### PR TITLE
Configurable HTTP Timeout

### DIFF
--- a/sigopt/interface.py
+++ b/sigopt/interface.py
@@ -183,6 +183,9 @@ class ConnectionImpl(object):
   def set_proxies(self, proxies):
     self.requestor.proxies = proxies
 
+  def set_timeout(self, timeout):
+    self.requestor.timeout = timeout
+
 
 class Connection(object):
   """
@@ -215,6 +218,9 @@ class Connection(object):
 
   def set_proxies(self, proxies):
     self.impl.set_proxies(proxies)
+
+  def set_timeout(self, timeout):
+    self.impl.set_timeout(timeout)
 
   @property
   def clients(self):

--- a/sigopt/requestor.py
+++ b/sigopt/requestor.py
@@ -4,9 +4,10 @@ from .compat import json as simplejson
 from .exception import ApiException, ConnectionException
 
 DEFAULT_API_URL = 'https://api.sigopt.com'
+DEFAULT_HTTP_TIMEOUT = 150
 
 class Requestor(object):
-  def __init__(self, user, password, headers, verify_ssl_certs=True, proxies=None):
+  def __init__(self, user, password, headers, verify_ssl_certs=True, proxies=None, timeout=DEFAULT_HTTP_TIMEOUT):
     if user is not None:
       self.auth = requests.auth.HTTPBasicAuth(user, password)
     else:
@@ -14,6 +15,7 @@ class Requestor(object):
     self.default_headers = headers or {}
     self.verify_ssl_certs = verify_ssl_certs
     self.proxies = proxies
+    self.timeout = timeout
     self._session = requests.Session()
 
   def get(self, url, params=None, json=None, headers=None):
@@ -40,6 +42,7 @@ class Requestor(object):
         headers=headers,
         verify=self.verify_ssl_certs,
         proxies=self.proxies,
+        timeout=self.timeout,
       )
     except requests.exceptions.RequestException as e:
       message = ['An error occurred connecting to SigOpt.']

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -3,6 +3,7 @@ import pytest
 import mock
 
 from sigopt.interface import Connection
+from sigopt.requestor import DEFAULT_HTTP_TIMEOUT
 from sigopt.resource import ApiResource
 
 class TestInterface(object):
@@ -11,6 +12,7 @@ class TestInterface(object):
     assert conn.impl.api_url == 'https://api.sigopt.com'
     assert conn.impl.requestor.verify_ssl_certs is True
     assert conn.impl.requestor.proxies is None
+    assert conn.impl.requestor.timeout == DEFAULT_HTTP_TIMEOUT
     assert isinstance(conn.clients, ApiResource)
     assert isinstance(conn.experiments, ApiResource)
 
@@ -42,3 +44,8 @@ class TestInterface(object):
     with mock.patch.dict(os.environ, {'SIGOPT_API_TOKEN': ''}):
       with pytest.raises(ValueError):
         Connection()
+
+  def test_timeout(self):
+    conn = Connection('client_token')
+    conn.set_timeout(30)
+    assert conn.impl.requestor.timeout == 30


### PR DESCRIPTION
Add configurable HTTP timeout for a `Connection`. Setting the timeout would look something like: `conn.set_timeout(5)`