### PR TITLE
Fix install on platforms without `requests`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
+import os
 import sys
 import warnings
 
 from setuptools import setup
-from sigopt.version import VERSION
 
 if sys.version_info < (2, 7):
   warnings.warn(
@@ -13,6 +13,17 @@ if sys.version_info < (2, 7):
 
 # keep this in sync with requirements.txt
 install_requires = ['requests>=2.11.1']
+
+# NOTE(patrick): We can't `import sigopt.version` directly, because that
+# will cause us to execute `sigopt/__init__.py`, which may transitively import
+# packages that may not have been installed yet. So jump straight to sigopt/version.py
+# and execute that directly, which should be simple enough that it doesn't import anything
+# Learned from https://github.com/stripe/stripe-python (MIT licensed)
+version_contents = {}
+here = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(here, 'sigopt', 'version.py'), encoding='utf-8') as f:
+  exec(f.read(), version_contents)
+VERSION = version_contents['VERSION']
 
 setup(
   name='sigopt',

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from codecs import open
 import os
 import sys
 import warnings


### PR DESCRIPTION
Can occur when you are installing via pip in a fresh virtualenv

```
$ pip install -e ".[dev]"
Obtaining file:///Users/patrick/dev/sigopt-python
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/Users/patrick/dev/sigopt-python/setup.py", line 5, in <module>
        from sigopt.version import VERSION
      File "/Users/patrick/dev/sigopt-python/sigopt/__init__.py", line 1, in <module>
        from .interface import Connection
      File "/Users/patrick/dev/sigopt-python/sigopt/interface.py", line 20, in <module>
        from .requestor import Requestor, DEFAULT_API_URL
      File "/Users/patrick/dev/sigopt-python/sigopt/requestor.py", line 1, in <module>
        import requests
    ModuleNotFoundError: No module named 'requests'
```

@alexandraj777