### PR TITLE
Max retries for Requestor object

### DIFF
--- a/sigopt/requestor.py
+++ b/sigopt/requestor.py
@@ -8,7 +8,16 @@ DEFAULT_HTTP_TIMEOUT = 150
 DEFAULT_MAX_RETRIES = 1
 
 class Requestor(object):
-  def __init__(self, user, password, headers, verify_ssl_certs=True, proxies=None, timeout=DEFAULT_HTTP_TIMEOUT, max_retries=DEFAULT_MAX_RETRIES):
+  def __init__(
+    self,
+    user,
+    password,
+    headers,
+    verify_ssl_certs=True,
+    proxies=None,
+    timeout=DEFAULT_HTTP_TIMEOUT,
+    max_retries=DEFAULT_MAX_RETRIES,
+  ):
     if user is not None:
       self.auth = requests.auth.HTTPBasicAuth(user, password)
     else:

--- a/sigopt/requestor.py
+++ b/sigopt/requestor.py
@@ -5,9 +5,10 @@ from .exception import ApiException, ConnectionException
 
 DEFAULT_API_URL = 'https://api.sigopt.com'
 DEFAULT_HTTP_TIMEOUT = 150
+DEFAULT_MAX_RETRIES = 1
 
 class Requestor(object):
-  def __init__(self, user, password, headers, verify_ssl_certs=True, proxies=None, timeout=DEFAULT_HTTP_TIMEOUT):
+  def __init__(self, user, password, headers, verify_ssl_certs=True, proxies=None, timeout=DEFAULT_HTTP_TIMEOUT, max_retries=DEFAULT_MAX_RETRIES):
     if user is not None:
       self.auth = requests.auth.HTTPBasicAuth(user, password)
     else:
@@ -17,6 +18,9 @@ class Requestor(object):
     self.proxies = proxies
     self.timeout = timeout
     self._session = requests.Session()
+    adapter = requests.adapters.HTTPAdapter(max_retries=max_retries)
+    self._session.mount('http://', adapter)
+    self._session.mount('https://', adapter)
 
   def get(self, url, params=None, json=None, headers=None):
     return self.request('get', url=url, params=params, json=json, headers=headers)


### PR DESCRIPTION
https://github.com/requests/requests/issues/4664 gives a good explanation of the problem:

> If python sends a request at roughly the same time as the server closes the
session, then the server will send a RST (as the session is closed). Python
receives this RST on what it thought was a valid session and throws an
error

This can be handled by setting `max_retries` in the `requests.adapters.HTTPAdapter` class (the requests default is 0) which will retry on a `ConnectionError`.