### PR TITLE
Serialize objects

### DIFF
--- a/sigopt/objects.py
+++ b/sigopt/objects.py
@@ -135,7 +135,11 @@ class ApiObject(BaseApiObject):
         return six.u('{0}{\n{1},\n{0}}').format(
           indent,
           six.u(',\n').join([
-            six.u('  {0}"{1}"={2}').format(indent, key, ApiObject.dumps(obj[key], indent_level=indent_level + 2).lstrip())
+            six.u('  {0}"{1}"={2}').format(
+              indent,
+              key,
+              ApiObject.dumps(obj[key], indent_level=indent_level + 2).lstrip()
+            )
             for key
             in obj
           ])

--- a/sigopt/objects.py
+++ b/sigopt/objects.py
@@ -2,7 +2,7 @@ import copy
 import warnings
 
 from .compat import json
-from .lib import is_sequence, is_mapping, is_integer, is_number, is_numpy_array
+from .lib import is_sequence, is_mapping, is_integer, is_number, is_numpy_array, is_string
 from .vendored import six as six
 
 
@@ -71,15 +71,22 @@ class BaseApiObject(object):
       return subvalue if isinstance(subvalue, Field) else None
 
   def __repr__(self):
-    return six.u('{0}({1})').format(
-      self.__class__.__name__,
-      json.dumps(
-        ApiObject.as_json(self._body),
-        indent=2,
-        sort_keys=True,
-        separators=(',', ': '),
-      ),
-    )
+    attributes = dir(self)
+    attributes = [a for a in attributes if not a.startswith('_')]
+    attributes = [a for a in attributes if not callable(getattr(self, a))]
+    keys_in_json = set(ApiObject.as_json(self._body).keys())
+    keys = keys_in_json.intersection(set(attributes))
+
+    if keys:
+      return six.u('{0}(\n{1}\n)').format(
+        self.__class__.__name__,
+        '\n'.join([
+          six.u('  {}={},').format(key, ApiObject.dumps(getattr(self, key), indent_level=2).lstrip())
+          for key
+          in keys
+        ]),
+      )
+    return six.u('{0}()').format(self.__class__.__name__)
 
   def to_json(self):
     return copy.deepcopy(self._body)
@@ -117,6 +124,43 @@ class ApiObject(BaseApiObject):
       return float(obj)
     return obj
 
+  @staticmethod
+  def dumps(obj, indent_level=0):
+    indent = ' ' * indent_level
+
+    if isinstance(obj, BaseApiObject):
+      return six.u('{0}{1}'.format(indent, str(obj).replace('\n', '\n{0}'.format(indent))))
+    if is_mapping(obj):
+      if obj:
+        return six.u('{0}{\n{1},\n{0}}').format(
+          indent,
+          six.u(',\n').join([
+            six.u('  {0}"{1}"={2}').format(indent, key, ApiObject.dumps(obj[key], indent_level=indent_level + 2).lstrip())
+            for key
+            in obj
+          ])
+        )
+      return six.u('{0}{1}'.format(indent, str(obj)))
+    if is_numpy_array(obj):
+      return ApiObject.dumps(obj.tolist(), indent_level=indent_level)
+    if is_sequence(obj):
+      if obj:
+        return six.u('{0}[\n{1},\n{0}]').format(
+          indent,
+          six.u(',\n').join([
+            ApiObject.dumps(c, indent_level=indent_level + 2)
+            for c
+            in obj
+          ])
+        )
+      return six.u('{0}{1}'.format(indent, str(obj)))
+    if is_integer(obj):
+      return six.u('{0}{1}'.format(indent, str(int(obj))))
+    if is_number(obj):
+      return six.u('{0}{1}'.format(indent, str(float(obj))))
+    if is_string(obj):
+      return six.u('{0}"{1}"'.format(indent, obj))
+    return six.u('{0}{1}'.format(indent, obj))
 
 class _DictWrapper(BaseApiObject, dict):
   def __init__(self, body, bound_endpoint=None, retrieve_params=None):
@@ -141,6 +185,16 @@ class _DictWrapper(BaseApiObject, dict):
       dict.__eq__(self, other)
     )
 
+  def __repr__(self):
+    return six.u('{0}({1})').format(
+      self.__class__.__name__,
+      json.dumps(
+        ApiObject.as_json(self._body),
+        indent=2,
+        sort_keys=True,
+        separators=(',', ': '),
+      ),
+    )
 
 class Assignments(_DictWrapper):
   pass

--- a/test/test_object.py
+++ b/test/test_object.py
@@ -67,12 +67,15 @@ class TestBase(object):
     assert Assignments({'a': 'b'}) != Assignments({'a': 'b', 'c': 'd'})
 
   def test_repr(self):
-    assert repr(Experiment({})) == 'Experiment({})'
-    assert repr(Experiment({'a': 'b'})) == 'Experiment({\n  "a": "b"\n})'
+    assert repr(Experiment({})) == 'Experiment()'
+    assert repr(Experiment({'user': 'b'})) == 'Experiment(\n  user="b",\n)'
     assert repr(Assignments({})) == 'Assignments({})'
     assert repr(Assignments({'a': 'b'})) == 'Assignments({\n  "a": "b"\n})'
     assert repr(Assignments({'a': 'b', 'c': 'd'})) == 'Assignments({\n  "a": "b",\n  "c": "d"\n})'
-    assert repr(Bounds({'a': 'b'})) == 'Bounds({\n  "a": "b"\n})'
+    assert (
+        repr(Bounds({'max': 0.1, 'min': -0.2})) == 'Bounds(\n  max=0.1,\n  min=-0.2,\n)'
+        or repr(Bounds({'max': 0.1, 'min': -0.2})) == 'Bounds(\n  min=-0.2,\n  max=0.1,\n)'
+    )
 
   def test_json(self):
     assert Experiment({}).to_json() == {}


### PR DESCRIPTION
Will rebase after merging #130 

After observing dozens of engineers use our API client in ipython notebooks, it's clear that our object serialization causes users to think that field access on objects like `Experiment` and `Metric` is done via square brackets. The goal of this PR is to change the serialization of the appropriate API objects so that users are nudged as to when they should use dot notation to access a field, and when they should use square brackets.

At the end of this description, I've included an example of the dramatic difference between in the `Experiment` object. Note how it's much cognitively easier to interpret the types of all of the sub-objects nested into the `Experiment`, both because of capitalization of object names, but also the `=` vs the `:` separators. Also note how users can take advantage of better syntax highlighting.

# Before
We know that fields on the `Metric` object should be accessed with dot notation, and fields on `Assignments` should be accessed with square brackets. However, you both the `Metric` and the `Assignments` objects are serialized in the same way. A user would be forgiven for thinking that they could simply use `metric["name"]` to access a field on a metric object.

```python
Metric({
  "name": "accuracy",
  "object": "metric",
  "value_baseline": null
})
Assignments({
  "l1_ratio": 0.773720856744806,
  "log_alpha": -4.998613583434301
})
```

# After
Now, `Metric` "looks like" a python object, and queued the user to type `metric.name`. `Assignments` is left unchanged, to nudge the user towards accessing fields like `assignments["l1_ratio"]`.

```python
Metric(
  value_baseline=None,
  name="accuracy",
)
Assignments({
  "l1_ratio": 0.773720856744806,
  "log_alpha": -4.998613583434301
})
```
# Experiment Object - Before
```python
Experiment({
  "client": "9004",
  "conditionals": [],
  "created": 1545358350,
  "development": false,
  "folds": null,
  "id": "58279",
  "linear_constraints": [],
  "max_checkpoints": null,
  "metadata": {
    "orchestrate_experiment": "True"
  },
  "metric": {
    "name": "accuracy",
    "object": "metric",
    "value_baseline": null
  },
  "metrics": [
    {
      "name": "accuracy",
      "object": "metric",
      "value_baseline": null
    }
  ],
  "name": "Orchestrate SGD Classifier (python)",
  "num_solutions": null,
  "object": "experiment",
  "observation_budget": 60,
  "parallel_bandwidth": 2,
  "parameters": [
    {
      "bounds": {
        "max": 1.0,
        "min": 0.0,
        "object": "bounds"
      },
      "categorical_values": null,
      "conditions": {},
      "default_value": null,
      "name": "l1_ratio",
      "object": "parameter",
      "precision": null,
      "tunable": true,
      "type": "double"
    },
    {
      "bounds": {
        "max": 2.0,
        "min": -5.0,
        "object": "bounds"
      },
      "categorical_values": null,
      "conditions": {},
      "default_value": null,
      "name": "log_alpha",
      "object": "parameter",
      "precision": null,
      "tunable": true,
      "type": "double"
    }
  ],
  "progress": {
    "best_observation": {
      "assignments": {
        "l1_ratio": 1.0,
        "log_alpha": -2.118473953259465
      },
      "created": 1545358374,
      "experiment": "58279",
      "failed": false,
      "id": "7433338",
      "metadata": {
        "loss": "log",
        "max_iter": 1000,
        "penalty": "elasticnet",
        "pod_name": "orchestrate-58279-qwkft",
        "tol": 0.001
      },
      "object": "observation",
      "suggestion": "22380801",
      "value": 0.9666666666666668,
      "value_stddev": 0.029814239699997188,
      "values": [
        {
          "name": "accuracy",
          "object": "metric_evaluation",
          "value": 0.9666666666666668,
          "value_stddev": 0.029814239699997188
        }
      ]
    },
    "first_observation": {
      "assignments": {
        "l1_ratio": 0.773720856744806,
        "log_alpha": -4.998613583434301
      },
      "created": 1545358353,
      "experiment": "58279",
      "failed": false,
      "id": "7433301",
      "metadata": {
        "loss": "log",
        "max_iter": 1000,
        "penalty": "elasticnet",
        "pod_name": "orchestrate-58279-w55qr",
        "tol": 0.001
      },
      "object": "observation",
      "suggestion": "22380764",
      "value": 0.6399999999999999,
      "value_stddev": 0.15114378731672848,
      "values": [
        {
          "name": "accuracy",
          "object": "metric_evaluation",
          "value": 0.6399999999999999,
          "value_stddev": 0.15114378731672848
        }
      ]
    },
    "last_observation": {
      "assignments": {
        "l1_ratio": 0.826468076347503,
        "log_alpha": -1.1484302407528824
      },
      "created": 1545358388,
      "experiment": "58279",
      "failed": false,
      "id": "7433361",
      "metadata": {
        "loss": "log",
        "max_iter": 1000,
        "penalty": "elasticnet",
        "pod_name": "orchestrate-58279-w55qr",
        "tol": 0.001
      },
      "object": "observation",
      "suggestion": "22380824",
      "value": 0.78,
      "value_stddev": 0.10456258094238749,
      "values": [
        {
          "name": "accuracy",
          "object": "metric_evaluation",
          "value": 0.78,
          "value_stddev": 0.10456258094238749
        }
      ]
    },
    "object": "progress",
    "observation_budget_consumed": 61.0,
    "observation_count": 61
  },
  "state": "active",
  "type": "offline",
  "updated": 1545358388,
  "user": "702"
})
```
# Experiment Object - After
```python
Experiment(
  progress=Progress(
    first_observation=Observation(
      values=[
        MetricEvaluation(
          value=0.6399999999999999,
          name="accuracy",
          value_stddev=0.15114378731672848,
        ),
      ],
      failed=False,
      value=0.6399999999999999,
      id="7433301",
      metadata=Metadata({
        "loss": "log",
        "max_iter": 1000,
        "penalty": "elasticnet",
        "pod_name": "orchestrate-58279-w55qr",
        "tol": 0.001
      }),
      value_stddev=0.15114378731672848,
      created=1545358353,
      assignments=Assignments({
        "l1_ratio": 0.773720856744806,
        "log_alpha": -4.998613583434301
      }),
      suggestion="22380764",
      experiment="58279",
    ),
    best_observation=Observation(
      values=[
        MetricEvaluation(
          value=0.9666666666666668,
          name="accuracy",
          value_stddev=0.029814239699997188,
        ),
      ],
      failed=False,
      value=0.9666666666666668,
      id="7433338",
      metadata=Metadata({
        "loss": "log",
        "max_iter": 1000,
        "penalty": "elasticnet",
        "pod_name": "orchestrate-58279-qwkft",
        "tol": 0.001
      }),
      value_stddev=0.029814239699997188,
      created=1545358374,
      assignments=Assignments({
        "l1_ratio": 1.0,
        "log_alpha": -2.118473953259465
      }),
      suggestion="22380801",
      experiment="58279",
    ),
    last_observation=Observation(
      values=[
        MetricEvaluation(
          value=0.78,
          name="accuracy",
          value_stddev=0.10456258094238749,
        ),
      ],
      failed=False,
      value=0.78,
      id="7433361",
      metadata=Metadata({
        "loss": "log",
        "max_iter": 1000,
        "penalty": "elasticnet",
        "pod_name": "orchestrate-58279-w55qr",
        "tol": 0.001
      }),
      value_stddev=0.10456258094238749,
      created=1545358388,
      assignments=Assignments({
        "l1_ratio": 0.826468076347503,
        "log_alpha": -1.1484302407528824
      }),
      suggestion="22380824",
      experiment="58279",
    ),
    observation_budget_consumed=61.0,
    observation_count=61,
  ),
  metadata=Metadata({
    "orchestrate_experiment": "True"
  }),
  num_solutions=None,
  state="active",
  folds=None,
  type="offline",
  name="Orchestrate SGD Classifier (python)",
  updated=1545358388,
  conditionals=[],
  parallel_bandwidth=2,
  created=1545358350,
  max_checkpoints=None,
  metric=Metric(
    value_baseline=None,
    name="accuracy",
  ),
  linear_constraints=[],
  client="9004",
  metrics=[
    Metric(
      value_baseline=None,
      name="accuracy",
    ),
  ],
  observation_budget=60,
  development=False,
  id="58279",
  parameters=[
    Parameter(
      conditions=Conditions({}),
      type="double",
      name="l1_ratio",
      bounds=Bounds(
        max=1.0,
        min=0.0,
      ),
      default_value=None,
      precision=None,
      categorical_values=None,
      tunable=True,
    ),
    Parameter(
      conditions=Conditions({}),
      type="double",
      name="log_alpha",
      bounds=Bounds(
        max=2.0,
        min=-5.0,
      ),
      default_value=None,
      precision=None,
      categorical_values=None,
      tunable=True,
    ),
  ],
  user="702",
)
```