### PR TITLE
Client certificates

### DIFF
--- a/sigopt/interface.py
+++ b/sigopt/interface.py
@@ -206,14 +206,6 @@ class ConnectionImpl(object):
       ],
     )
 
-    self.sessions = ApiResource(
-      self,
-      'sessions',
-      endpoints=[
-        ApiEndpoint(None, Session, 'GET', 'fetch'),
-      ],
-    )
-
     self.pki_sessions = ApiResource(
       self,
       'pki_sessions',
@@ -279,6 +271,9 @@ class ConnectionImpl(object):
   def set_ca_bundle(self, ca_bundle):
     self.requestor.ca_bundle = ca_bundle
 
+  def set_client_token(self, client_token):
+    self.requestor.set_client_token(client_token)
+
 
 class Connection(object):
   """
@@ -321,6 +316,9 @@ class Connection(object):
   def set_ca_bundle(self, ca_bundle):
     self.impl.set_ca_bundle(ca_bundle)
 
+  def set_client_token(self, client_token):
+    self.impl.set_client_token(client_token)
+
   @property
   def clients(self):
     return self.impl.clients
@@ -336,10 +334,6 @@ class Connection(object):
   @property
   def pki_sessions(self):
     return self.impl.pki_sessions
-
-  @property
-  def sessions(self):
-    return self.impl.sessions
 
 
 def paginated_objects(api_object):

--- a/sigopt/interface.py
+++ b/sigopt/interface.py
@@ -77,6 +77,7 @@ class ConnectionImpl(object):
       'tokens',
       endpoints=[
         ApiEndpoint(None, Token, 'POST', 'create'),
+        ApiEndpoint(None, object_or_paginated_objects(Token), 'GET', 'fetch'),
       ],
     )
 
@@ -193,6 +194,7 @@ class ConnectionImpl(object):
         client_experiments,
         client_projects,
         plan,
+        tokens,
       ],
     )
 
@@ -201,6 +203,14 @@ class ConnectionImpl(object):
       'organizations',
       endpoints=[
         ApiEndpoint(None, object_or_paginated_objects(Organization), 'GET', 'fetch'),
+      ],
+    )
+
+    self.sessions = ApiResource(
+      self,
+      'sessions',
+      endpoints=[
+        ApiEndpoint(None, Session, 'GET', 'fetch'),
       ],
     )
 
@@ -326,6 +336,10 @@ class Connection(object):
   @property
   def pki_sessions(self):
     return self.impl.pki_sessions
+
+  @property
+  def sessions(self):
+    return self.impl.sessions
 
 
 def paginated_objects(api_object):

--- a/sigopt/interface.py
+++ b/sigopt/interface.py
@@ -16,6 +16,7 @@ from .objects import (
   Plan,
   Project,
   QueuedSuggestion,
+  Session,
   StoppingCriteria,
   Suggestion,
   Token,
@@ -203,6 +204,14 @@ class ConnectionImpl(object):
       ],
     )
 
+    self.pki_sessions = ApiResource(
+      self,
+      'pki_sessions',
+      endpoints=[
+        ApiEndpoint(None, Session, 'POST', 'create'),
+      ],
+    )
+
   def _request(self, method, url, params):
     if method.upper() in ('GET', 'DELETE'):
       json, params = None, self._request_params(params)
@@ -254,6 +263,12 @@ class ConnectionImpl(object):
   def set_timeout(self, timeout):
     self.requestor.timeout = timeout
 
+  def set_client_ssl_certs(self, client_ssl_certs):
+    self.requestor.client_ssl_certs = client_ssl_certs
+
+  def set_ca_bundle(self, ca_bundle):
+    self.requestor.ca_bundle = ca_bundle
+
 
 class Connection(object):
   """
@@ -290,6 +305,12 @@ class Connection(object):
   def set_timeout(self, timeout):
     self.impl.set_timeout(timeout)
 
+  def set_client_ssl_certs(self, client_ssl_certs):
+    self.impl.set_client_ssl_certs(client_ssl_certs)
+
+  def set_ca_bundle(self, ca_bundle):
+    self.impl.set_ca_bundle(ca_bundle)
+
   @property
   def clients(self):
     return self.impl.clients
@@ -301,6 +322,10 @@ class Connection(object):
   @property
   def organizations(self):
     return self.impl.organizations
+
+  @property
+  def pki_sessions(self):
+    return self.impl.pki_sessions
 
 
 def paginated_objects(api_object):

--- a/sigopt/interface.py
+++ b/sigopt/interface.py
@@ -313,16 +313,6 @@ class Connection(object):
   def set_client_token(self, client_token):
     self.impl.set_client_token(client_token)
 
-  def pki_login(self, client_id=None, development=False):
-    session = self.pki_sessions().create()
-    client_id = client_id or session.client.id
-    self.set_client_token(session.api_token.token)
-    client_tokens = self.clients(client_id).tokens().fetch()
-    for token in client_tokens.data:
-      if token.development == development:
-        self.set_client_token(token.token)
-        break
-
   @property
   def clients(self):
     return self.impl.clients

--- a/sigopt/interface.py
+++ b/sigopt/interface.py
@@ -268,9 +268,6 @@ class ConnectionImpl(object):
   def set_client_ssl_certs(self, client_ssl_certs):
     self.requestor.client_ssl_certs = client_ssl_certs
 
-  def set_ca_bundle(self, ca_bundle):
-    self.requestor.ca_bundle = ca_bundle
-
   def set_client_token(self, client_token):
     self.requestor.set_client_token(client_token)
 
@@ -312,9 +309,6 @@ class Connection(object):
 
   def set_client_ssl_certs(self, client_ssl_certs):
     self.impl.set_client_ssl_certs(client_ssl_certs)
-
-  def set_ca_bundle(self, ca_bundle):
-    self.impl.set_ca_bundle(ca_bundle)
 
   def set_client_token(self, client_token):
     self.impl.set_client_token(client_token)

--- a/sigopt/interface.py
+++ b/sigopt/interface.py
@@ -319,6 +319,16 @@ class Connection(object):
   def set_client_token(self, client_token):
     self.impl.set_client_token(client_token)
 
+  def pki_login(self, client_id=None, development=False):
+    session = self.pki_sessions().create()
+    client_id = client_id or session.client.id
+    self.set_client_token(session.api_token.token)
+    client_tokens = self.clients(client_id).tokens().fetch()
+    for token in client_tokens.data:
+      if token.development == development:
+        self.set_client_token(token.token)
+        break
+
   @property
   def clients(self):
     return self.impl.clients
@@ -334,7 +344,6 @@ class Connection(object):
   @property
   def pki_sessions(self):
     return self.impl.pki_sessions
-
 
 def paginated_objects(api_object):
   def decorator(body, *args, **kwargs):

--- a/sigopt/objects.py
+++ b/sigopt/objects.py
@@ -505,3 +505,17 @@ class Checkpoint(ApiObject):
   stopping_reasons = Field(StoppingReasons)
   training_run = Field(str)
   values = Field(ListOf(MetricEvaluation))
+
+
+class ApiToken(_DictWrapper):
+  pass
+
+
+class User(_DictWrapper):
+  pass
+
+
+class Session(ApiObject):
+  api_token = Field(ApiToken)
+  client = Field(Client)
+  user = Field(User)

--- a/sigopt/objects.py
+++ b/sigopt/objects.py
@@ -507,15 +507,11 @@ class Checkpoint(ApiObject):
   values = Field(ListOf(MetricEvaluation))
 
 
-class ApiToken(_DictWrapper):
-  pass
-
-
 class User(_DictWrapper):
   pass
 
 
 class Session(ApiObject):
-  api_token = Field(ApiToken)
+  api_token = Field(Token)
   client = Field(Client)
   user = Field(User)

--- a/sigopt/objects.py
+++ b/sigopt/objects.py
@@ -507,8 +507,12 @@ class Checkpoint(ApiObject):
   values = Field(ListOf(MetricEvaluation))
 
 
-class User(_DictWrapper):
-  pass
+class User(ApiObject):
+  created = Field(int)
+  deleted = Field(bool)
+  email = Field(str)
+  id = Field(str)
+  name = Field(str)
 
 
 class Session(ApiObject):

--- a/sigopt/requestor.py
+++ b/sigopt/requestor.py
@@ -29,6 +29,12 @@ class Requestor(object):
     self.timeout = timeout
     self.client_ssl_certs = client_ssl_certs
 
+  def set_client_token(self, client_token):
+    if client_token is not None:
+      self.auth = requests.auth.HTTPBasicAuth(client_token, '')
+    else:
+      self.auth = None
+
   def get(self, url, params=None, json=None, headers=None):
     return self.request('get', url=url, params=params, json=json, headers=headers)
 

--- a/sigopt/requestor.py
+++ b/sigopt/requestor.py
@@ -49,9 +49,6 @@ class Requestor(object):
 
   def request(self, method, url, params=None, json=None, headers=None):
     headers = self._with_default_headers(headers)
-    verify = self.verify_ssl_certs
-    if verify and self.ca_bundle:
-      verify = self.ca_bundle
     try:
       response = requests.request(
         method=method,
@@ -60,7 +57,7 @@ class Requestor(object):
         json=json,
         auth=self.auth,
         headers=headers,
-        verify=verify,
+        verify=self.verify_ssl_certs,
         proxies=self.proxies,
         timeout=self.timeout,
         cert=self.client_ssl_certs,

--- a/sigopt/requestor.py
+++ b/sigopt/requestor.py
@@ -15,6 +15,8 @@ class Requestor(object):
     verify_ssl_certs=True,
     proxies=None,
     timeout=DEFAULT_HTTP_TIMEOUT,
+    client_ssl_certs=None,
+    ca_bundle=None,
   ):
     if user is not None:
       self.auth = requests.auth.HTTPBasicAuth(user, password)
@@ -22,8 +24,10 @@ class Requestor(object):
       self.auth = None
     self.default_headers = headers or {}
     self.verify_ssl_certs = verify_ssl_certs
+    self.ca_bundle = ca_bundle
     self.proxies = proxies
     self.timeout = timeout
+    self.client_ssl_certs = client_ssl_certs
 
   def get(self, url, params=None, json=None, headers=None):
     return self.request('get', url=url, params=params, json=json, headers=headers)
@@ -39,6 +43,9 @@ class Requestor(object):
 
   def request(self, method, url, params=None, json=None, headers=None):
     headers = self._with_default_headers(headers)
+    verify = self.verify_ssl_certs
+    if verify and self.ca_bundle:
+      verify = self.ca_bundle
     try:
       response = requests.request(
         method=method,
@@ -47,9 +54,10 @@ class Requestor(object):
         json=json,
         auth=self.auth,
         headers=headers,
-        verify=self.verify_ssl_certs,
+        verify=verify,
         proxies=self.proxies,
         timeout=self.timeout,
+        cert=self.client_ssl_certs,
       )
     except requests.exceptions.RequestException as e:
       message = ['An error occurred connecting to SigOpt.']

--- a/sigopt/requestor.py
+++ b/sigopt/requestor.py
@@ -17,21 +17,21 @@ class Requestor(object):
     timeout=DEFAULT_HTTP_TIMEOUT,
     client_ssl_certs=None,
   ):
-    if user is not None:
-      self.auth = requests.auth.HTTPBasicAuth(user, password)
-    else:
-      self.auth = None
+    self._set_auth(user, password)
     self.default_headers = headers or {}
     self.verify_ssl_certs = verify_ssl_certs
     self.proxies = proxies
     self.timeout = timeout
     self.client_ssl_certs = client_ssl_certs
 
-  def set_client_token(self, client_token):
-    if client_token is not None:
-      self.auth = requests.auth.HTTPBasicAuth(client_token, '')
+  def _set_auth(self, username, password):
+    if username is not None:
+      self.auth = requests.auth.HTTPBasicAuth(username, password)
     else:
       self.auth = None
+
+  def set_client_token(self, client_token):
+    self._set_auth(client_token, '')
 
   def get(self, url, params=None, json=None, headers=None):
     return self.request('get', url=url, params=params, json=json, headers=headers)

--- a/sigopt/requestor.py
+++ b/sigopt/requestor.py
@@ -16,7 +16,6 @@ class Requestor(object):
     proxies=None,
     timeout=DEFAULT_HTTP_TIMEOUT,
     client_ssl_certs=None,
-    ca_bundle=None,
   ):
     if user is not None:
       self.auth = requests.auth.HTTPBasicAuth(user, password)
@@ -24,7 +23,6 @@ class Requestor(object):
       self.auth = None
     self.default_headers = headers or {}
     self.verify_ssl_certs = verify_ssl_certs
-    self.ca_bundle = ca_bundle
     self.proxies = proxies
     self.timeout = timeout
     self.client_ssl_certs = client_ssl_certs


### PR DESCRIPTION
Enables a few separate but related pieces:
  - ~`ca_bundle`: useful if sigopt is run with SSL certs not recognized by default~
  - `client_ssl_certs`: useful if client authentication is done via SSL / PKI, rather than username/password
  - `pki_sessions()` for lower-level connecting
  - ~`pki_login()` convenience function for navigating a full PKI connection~