### PR TITLE
log_metrics method

### DIFF
--- a/sigopt/__init__.py
+++ b/sigopt/__init__.py
@@ -15,6 +15,7 @@ log_failure = _global_run_context.log_failure
 log_image = _global_run_context.log_image
 log_metadata = _global_run_context.log_metadata
 log_metric = _global_run_context.log_metric
+log_metrics = _global_run_context.log_metrics
 log_model = _global_run_context.log_model
 config.set_context_entry(_global_run_context)
 

--- a/sigopt/run_context.py
+++ b/sigopt/run_context.py
@@ -150,8 +150,8 @@ class BaseRunContext(object):
 
   def log_metrics(self, *args, **metric_kwargs):
     '''
-    sigopt.log_metric(metrics_dict)
-    sigopt.log_metric(**metric_kwargs)
+    sigopt.log_metrics(metrics_dict)
+    sigopt.log_metrics(**metric_kwargs)
       Logs multiple metric values for your run. Metrics can be provided as a dictionary or as keyword arguments.
     metrics_dict: dict
       A dictionary of metrics to log.

--- a/sigopt/run_context.py
+++ b/sigopt/run_context.py
@@ -154,7 +154,7 @@ class BaseRunContext(object):
     sigopt.log_metrics(**metric_kwargs)
       Logs multiple metric values for your run. Metrics can be provided as a dictionary or as keyword arguments.
     metrics_dict: dict
-      A dictionary of metrics to log.
+      A dictionary mapping metric names to their values.
     '''
     all_metrics = dict()
     all_metrics.update(*args, **metric_kwargs)

--- a/sigopt/run_context.py
+++ b/sigopt/run_context.py
@@ -148,6 +148,22 @@ class BaseRunContext(object):
       metric_log['value_stddev'] = sanitize_number('metric stddev', name, stddev)
     self._log_metrics({name: metric_log})
 
+  def log_metrics(self, *args, **metric_kwargs):
+    '''
+    sigopt.log_metric(metrics_dict)
+    sigopt.log_metric(**metric_kwargs)
+      Logs multiple metric values for your run. Metrics can be provided as a dictionary or as keyword arguments.
+    metrics_dict: dict
+      A dictionary of metrics to log.
+    '''
+    all_metrics = dict()
+    all_metrics.update(*args, **metric_kwargs)
+    metric_logs = {}
+    for name, value in all_metrics.items():
+      validate_name('metric name', name)
+      metric_logs[name] = {"value": sanitize_number("metric", name, value)}
+    self._log_metrics(metric_logs)
+
   def log_model(self, type=None):
     '''
     sigopt.log_model(type=None)


### PR DESCRIPTION
This method makes it easier to log multiple metrics at once.
examples:
```python
sigopt.log_metrics({"m1": 5, "m2": 1})
sigopt.log_metrics(m1=5, m2=1)
```