### PR TITLE
sj/no-python2-kernel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,12 @@
 version: 2.1
 
 commands:
-  setup_python3_kernel:
-    steps: 
-      # Get jupyter notebook compilation working in Python 2 tests
-      # https://ipython.readthedocs.io/en/latest/install/kernel_install.html#kernels-for-python-2-and-3
-      - run: '[[ ! "$(python --version 2>&1)" = "Python 2."* ]] || curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py'
-      - run: '[[ ! "$(python --version 2>&1)" = "Python 2."* ]] || sudo python3 get-pip.py'
-      - run: '[[ ! "$(python --version 2>&1)" = "Python 2."* ]] || sudo python3 -m pip install ipykernel'
-      - run: '[[ ! "$(python --version 2>&1)" = "Python 2."* ]] || python3 -m ipykernel install --user'
-  setup:
     steps:
       - checkout
       - run: sudo make update
   test:
     steps:
       - setup
-      - setup_python3_kernel
       - run: make test
   lint:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 
 commands:
+  setup:
     steps:
       - checkout
       - run: sudo make update


### PR DESCRIPTION
I think we only needed to set the py3 kernel if we were running under py2? Or something? IDK but tests pass