### PR TITLE
fix missing process

### DIFF
--- a/sigopt/cli/utils.py
+++ b/sigopt/cli/utils.py
@@ -104,7 +104,10 @@ def run_subprocess_command(config, run_context, cmd, env=None):
   try:
     return_code = proc.wait()
   except KeyboardInterrupt:
-    os.kill(proc.pid, signal.SIGINT)
+    try:
+      os.kill(proc.pid, signal.SIGINT)
+    except ProcessLookupError:
+      pass
     proc.wait()
     raise
   finally:


### PR DESCRIPTION
KeyboardInterrupt sometimes causes a subsequent `ProcessLookupError` when the user's program exits quickly