### PR TITLE
use global_run_context.params if run.assignments is empty

### DIFF
--- a/sigopt/run_context.py
+++ b/sigopt/run_context.py
@@ -290,7 +290,7 @@ class RunContext(BaseRunContext):
     self.connection = connection
     self.run = run
     fixed_values = dict(run.assignments)
-    self._params = RunParameters(self, fixed_values)
+    self._params = RunParameters(self, fixed_values, global_run_context.params)
 
   def to_json(self):
     data = {"run": self.run.to_json()}

--- a/sigopt/run_params.py
+++ b/sigopt/run_params.py
@@ -7,8 +7,13 @@ _get = object.__getattribute__
 _set = object.__setattr__
 
 class RunParameters(MutableMapping):
-  def __init__(self, run_context, fixed_items):
-    _set(self, "__items", dict(fixed_items))
+  def __init__(self, run_context, fixed_items, default_items=None):
+    if default_items:
+      items = dict(default_items)
+      items.update(fixed_items)
+    else:
+      items = dict(fixed_items)
+    _set(self, "__items", items)
     _set(self, "__run_context", run_context)
     _set(self, "__fixed_keys", set(fixed_items.keys()))
 


### PR DESCRIPTION
#SN-257 