### PR TITLE
client-side rate-limit

### DIFF
--- a/sigopt/ratelimit.py
+++ b/sigopt/ratelimit.py
@@ -12,7 +12,6 @@ class _FailedStatusRateLimit(object):
   def increment_and_check(self):
     with self.thread_lock:
       self.count += 1
-    with self.thread_lock:
       multiples_over = self.count // self.limit
     if multiples_over:
       exponential_backoff = multiples_over ** 2

--- a/sigopt/ratelimit.py
+++ b/sigopt/ratelimit.py
@@ -1,30 +1,28 @@
-import datetime
 import random
+import threading
 import time
 
 
-class RateLimit(object):
+global_failed_status_count = 0
+thread_lock = threading.Lock()
+
+class FailedStatusRateLimit(object):
   def __init__(self, limit, key=None):
     self.limit = limit
     self.key = key
-    self.count = 0
-
-  @staticmethod
-  def _datetime_to_seconds(dt):
-    return int((dt - datetime.datetime(1970, 1, 1)).total_seconds())
-
-  @staticmethod
-  def now():
-    return RateLimit._datetime_to_seconds(datetime.datetime.now())
 
   def increment_and_check(self, value=None):
     if self.key is not None:
       if value != self.key:
         self.key = value
-        self.count = 0
-    self.count += 1
-    if self.count > self.limit:
+        self.clear()
+    with thread_lock:
+      global global_failed_status_count
+      global_failed_status_count += 1
+    if global_failed_status_count > self.limit:
       time.sleep(random.random() * 2)
 
   def clear(self):
-    self.count = 0
+    with thread_lock:
+      global global_failed_status_count
+      global_failed_status_count = 0

--- a/sigopt/ratelimit.py
+++ b/sigopt/ratelimit.py
@@ -3,25 +3,24 @@ import threading
 import time
 
 
-global_failed_status_count = 0
-thread_lock = threading.Lock()
-
-class FailedStatusRateLimit(object):
+class _FailedStatusRateLimit(object):
   def __init__(self, limit):
     self.limit = limit
+    self.thread_lock = threading.Lock()
+    self.count = 0
 
   def increment_and_check(self):
-    with thread_lock:
-      global global_failed_status_count
-      global_failed_status_count += 1
-
-    multiples_over = global_failed_status_count // self.limit
+    with self.thread_lock:
+      self.count += 1
+    with self.thread_lock:
+      multiples_over = self.count // self.limit
     if multiples_over:
       exponential_backoff = multiples_over ** 2
       jitter = random.random() * 2
       time.sleep(exponential_backoff + jitter)
 
   def clear(self):
-    with thread_lock:
-      global global_failed_status_count
-      global_failed_status_count = 0
+    with self.thread_lock:
+      self.count = 0
+
+failed_status_rate_limit = _FailedStatusRateLimit(5)

--- a/sigopt/ratelimit.py
+++ b/sigopt/ratelimit.py
@@ -14,8 +14,12 @@ class FailedStatusRateLimit(object):
     with thread_lock:
       global global_failed_status_count
       global_failed_status_count += 1
-    if global_failed_status_count > self.limit:
-      time.sleep(random.random() * 2)
+
+    multiples_over = global_failed_status_count // self.limit
+    if multiples_over:
+      exponential_backoff = multiples_over ** 2
+      jitter = random.random() * 2
+      time.sleep(exponential_backoff + jitter)
 
   def clear(self):
     with thread_lock:

--- a/sigopt/ratelimit.py
+++ b/sigopt/ratelimit.py
@@ -7,15 +7,10 @@ global_failed_status_count = 0
 thread_lock = threading.Lock()
 
 class FailedStatusRateLimit(object):
-  def __init__(self, limit, key=None):
+  def __init__(self, limit):
     self.limit = limit
-    self.key = key
 
-  def increment_and_check(self, value=None):
-    if self.key is not None:
-      if value != self.key:
-        self.key = value
-        self.clear()
+  def increment_and_check(self):
     with thread_lock:
       global global_failed_status_count
       global_failed_status_count += 1

--- a/sigopt/ratelimit.py
+++ b/sigopt/ratelimit.py
@@ -14,9 +14,9 @@ class _FailedStatusRateLimit(object):
       self.count += 1
       multiples_over = self.count // self.limit
     if multiples_over:
-      exponential_backoff = multiples_over ** 2
+      quadratic_backoff = multiples_over ** 2
       jitter = random.random() * 2
-      time.sleep(exponential_backoff + jitter)
+      time.sleep(quadratic_backoff + jitter)
 
   def clear(self):
     with self.thread_lock:

--- a/sigopt/ratelimit.py
+++ b/sigopt/ratelimit.py
@@ -1,0 +1,30 @@
+import datetime
+import random
+import time
+
+
+class RateLimit(object):
+  def __init__(self, limit, key=None):
+    self.limit = limit
+    self.key = key
+    self.count = 0
+
+  @staticmethod
+  def _datetime_to_seconds(dt):
+    return int((dt - datetime.datetime(1970, 1, 1)).total_seconds())
+
+  @staticmethod
+  def now():
+    return RateLimit._datetime_to_seconds(datetime.datetime.now())
+
+  def increment_and_check(self, value=None):
+    if self.key is not None:
+      if value != self.key:
+        self.key = value
+        self.count = 0
+    self.count += 1
+    if self.count > self.limit:
+      time.sleep(random.random() * 2)
+
+  def clear(self):
+    self.count = 0

--- a/sigopt/requestor.py
+++ b/sigopt/requestor.py
@@ -29,7 +29,7 @@ class Requestor(object):
     self.client_ssl_certs = client_ssl_certs
     self.session = session
     # NOTE: using second-level granularity for request ratelimiting
-    self._time_ratelimit = RateLimit(100, RateLimit.now())
+    self._time_ratelimit = RateLimit(30, RateLimit.now())
     self._failed_status_ratelimit = RateLimit(5)
 
   def _set_auth(self, username, password):

--- a/sigopt/requestor.py
+++ b/sigopt/requestor.py
@@ -3,7 +3,7 @@ import requests
 from .compat import json as simplejson
 from .config import config
 from .exception import ApiException, ConnectionException
-from .ratelimit import FailedStatusRateLimit
+from .ratelimit import failed_status_rate_limit
 from .version import VERSION
 
 DEFAULT_API_URL = 'https://api.sigopt.com'
@@ -29,7 +29,6 @@ class Requestor(object):
     self.client_ssl_certs = client_ssl_certs
     self.session = session
     # NOTE: using second-level granularity for request ratelimiting
-    self._failed_status_ratelimit = FailedStatusRateLimit(5)
 
   def _set_auth(self, username, password):
     if username is not None:
@@ -111,7 +110,7 @@ class Requestor(object):
         status_code = 500 if is_success else status_code
 
     if is_success:
-      self._failed_status_ratelimit.clear()
+      failed_status_rate_limit.clear()
       return response_json
-    self._failed_status_ratelimit.increment_and_check()
+    failed_status_rate_limit.increment_and_check()
     raise ApiException(response_json, status_code)

--- a/sigopt/requestor.py
+++ b/sigopt/requestor.py
@@ -28,7 +28,6 @@ class Requestor(object):
     self.timeout = timeout
     self.client_ssl_certs = client_ssl_certs
     self.session = session
-    # NOTE: using second-level granularity for request ratelimiting
 
   def _set_auth(self, username, password):
     if username is not None:


### PR DESCRIPTION
## Goal:
  - implement some small client-side backoff for users who accidentally make malformed calls in a tight loop

## Strategies:
  - `time-based rate-limiting`: users are allowed 30 requests per second
  - `failed-status rate-limiting`: if calls are continually failing, they shouldn't continue to come at a rapid pace

## Time-Based
Pretty straightforward - take a timestamp at second-level granularity, and once they reach the limit, we sleep for 1-2 seconds.

Shortcomings:
  - process (thread?) specific, so multiple processes / multiple machines won't get blocked as quickly

## Failed Status
Also straightforward - keep a running count of consecutive failed (`not (200 <= status <= 299)`) requests. Users are allowed 5 before we enforce a 1-2 second sleep. Resets on any successful request.

Benefits:
  - while it doesn't share token-based failures with other processes / machines, if there's a calling pattern that generates continual errors, all processes will start slowing down

## Overall
Users can always change this or remove it if they are so inclined, as it's client-side. The motivation is to prevent _accidental_ mishaps from users negatively impacting the system by slamming requests in a tight loop.