### PR TITLE
use the project runs endpoint to fetch runs

### DIFF
--- a/sigopt/experiment_context.py
+++ b/sigopt/experiment_context.py
@@ -1,3 +1,4 @@
+import json
 import threading
 
 from .run_factory import BaseRunFactory
@@ -54,7 +55,8 @@ class ExperimentContext(BaseRunFactory):
     return run_context
 
   def get_runs(self):
-    return self._connection.experiments(self.id).training_runs().fetch().iterate_pages()
+    return self._connection.clients(self.client).projects(self.project).training_runs().fetch(filters=json.dumps([{"field": "experiment", "operator": "==", "value":
+      self.id}])).iterate_pages()
 
   def get_best_runs(self):
     return self._connection.experiments(self.id).best_training_runs().fetch().iterate_pages()

--- a/sigopt/experiment_context.py
+++ b/sigopt/experiment_context.py
@@ -55,8 +55,11 @@ class ExperimentContext(BaseRunFactory):
     return run_context
 
   def get_runs(self):
-    return self._connection.clients(self.client).projects(self.project).training_runs().fetch(filters=json.dumps([{"field": "experiment", "operator": "==", "value":
-      self.id}])).iterate_pages()
+    return self._connection.clients(self.client).projects(self.project).training_runs().fetch(filters=json.dumps([{
+      "field": "experiment",
+      "operator": "==",
+      "value": self.id,
+    }])).iterate_pages()
 
   def get_best_runs(self):
     return self._connection.experiments(self.id).best_training_runs().fetch().iterate_pages()


### PR DESCRIPTION
I would consider it a bug that the experiment's training runs list endpoint does not return all attributes (because it was made for training monitor) but this is the minimal change to fix