### PR TITLE
no pystache license

### DIFF
--- a/LICENSES/third_party/third-party-licenses.txt
+++ b/LICENSES/third_party/third-party-licenses.txt
@@ -955,10 +955,6 @@ ________________________________________________________________________________
 
    pypng
 
-   pystache
-   Copyright (C) 2012 Chris Jerdonek.  All rights reserved.
-   Copyright (c) 2009 Chris Wanstrath
-
    PyYAML
    Copyright (c) 2017-2021 Ingy döt Net
    Copyright (c) 2006-2016 Kirill Simonov


### PR DESCRIPTION
if we keep `chevron`, we should update this section, but if it's going away here, this is a fine place to clean it up