### PR TITLE
req min version for external packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open(os.path.join(here, 'requirements.txt')) as requirements_fp:
 with open(os.path.join(here, 'requirements-dev.txt')) as requirements_dev_fp:
   dev_install_requires = requirements_dev_fp.read().split('\n')
 
-xgboost_install_requires = ['xgboost>=1.3.1', 'scikit-learn', 'numpy']
+xgboost_install_requires = ['xgboost>=1.3.1', 'scikit-learn>=0.23.2', 'numpy>=1.15.0']
 
 setup(
   name='sigopt',


### PR DESCRIPTION
Added min versions for scikit-learn and numpy.

`scikit-learn>=0.23.2` because `classification_report` usage
`numpy>=1.15.0` because of this is the earliest version that's compatible with python 3.7. If we don't need the python 3.7 compatibility, can lower numpy version even further.