### PR TITLE
quick fix for compute_metrics

### DIFF
--- a/sigopt/xgboost/compute_metrics.py
+++ b/sigopt/xgboost/compute_metrics.py
@@ -57,7 +57,11 @@ def compute_mse(y_true, y_pred):
 def compute_classification_metrics(run, bst, D_matrix_pair):
   D_matrix, D_name = D_matrix_pair
   preds = bst.predict(D_matrix)
-  preds = numpy.round(preds)
+  # Check shape of preds
+  if len(preds.shape) == 2:
+    preds = numpy.argmax(preds, axis=1)
+  else:
+    preds = numpy.round(preds)
   y_test = D_matrix.get_label()
   accuracy = compute_accuracy(y_test, preds)
   rep = compute_classification_report(y_test, preds)


### PR DESCRIPTION
fix issue where sometimes classification predictions are vector-valued instead of integers. 

Checked with multi:softmax and multi:softprob objectives and worked okay. 