### PR TITLE
fix to default eval name, added log_params option for experiments

### DIFF
--- a/sigopt/xgboost/run.py
+++ b/sigopt/xgboost/run.py
@@ -12,13 +12,14 @@ from .compute_metrics import compute_classification_metrics, compute_regression_
 from ..log_capture import SystemOutputStreamMonitor
 from .. import create_run
 
-DEFAULT_EVALS_NAME = 'Test Set'
+DEFAULT_EVALS_NAME = 'TestSet'
 DEFAULT_RUN_OPTIONS = {
   'log_sys_info': True,
   'log_stdout': True,
   'log_stderr': True,
   'log_checkpoints': True,
   'log_metrics': True,
+  'log_params': True,
   'log_feature_importance': True,
   'run': None
 }
@@ -221,8 +222,10 @@ def run(params, dtrain, num_boost_round=10, evals=None, callbacks=None, verbose_
   _run = XGBRun(params, dtrain, num_boost_round, evals, verbose_eval, callbacks, run_options)
   _run.make_run()
   _run.log_metadata()
-  _run.log_params()
+  if _run.run_options_parsed['log_params']:
+    _run.log_params()
   _run.form_callbacks()
+  print(_run.validation_sets)
   _run.train_xgb()
   _run.check_learning_task()
   if _run.run_options_parsed['log_metrics']:

--- a/sigopt/xgboost/run.py
+++ b/sigopt/xgboost/run.py
@@ -193,9 +193,9 @@ class XGBRun:
 
   def log_training_metrics(self):
     if self.is_regression:
-      compute_regression_metrics(self.run, self.bst, (self.dtrain, 'Training Set'))
+      compute_regression_metrics(self.run, self.bst, (self.dtrain, 'TrainingSet'))
     else:
-      compute_classification_metrics(self.run, self.bst, (self.dtrain, 'Training Set'))
+      compute_classification_metrics(self.run, self.bst, (self.dtrain, 'TrainingSet'))
 
   def log_validation_metrics(self):
     if self.validation_sets:

--- a/sigopt/xgboost/run.py
+++ b/sigopt/xgboost/run.py
@@ -225,7 +225,6 @@ def run(params, dtrain, num_boost_round=10, evals=None, callbacks=None, verbose_
   if _run.run_options_parsed['log_params']:
     _run.log_params()
   _run.form_callbacks()
-  print(_run.validation_sets)
   _run.train_xgb()
   _run.check_learning_task()
   if _run.run_options_parsed['log_metrics']:

--- a/sigopt/xgboost/run.py
+++ b/sigopt/xgboost/run.py
@@ -134,9 +134,8 @@ class XGBRun:
   def log_params(self):
     for name in self.params.keys():
       if name not in PARAMS_LOGGED_AS_METADATA:
-        self.run.params.update({name: self.params[name]})
-
-    self.run.params.num_boost_round = self.num_boost_round
+        self.run.params.setdefaults(self.params)
+    self.run.params.setdefaults({'num_boost_round': self.num_boost_round})
 
   def check_learning_task(self):
     config = self.bst.save_config()


### PR DESCRIPTION
DEFAULT_EVALS_NAME right now is "Test Set", and no good because it has a space, which XGBoost isn't happy about (an error gets thrown). So I changed it to "TestSet". 

I also added an additional flag "log_params" to DEFAULT_RUN_OPTIONS, which turns off param logging. This is important for for experiments because we do not want to automatically log the params that are optimized (Sigopt-python will throw an error if we try to do this; the params that are optimized are protected and cannot be modified)