### PR TITLE
Simplifying xgboost defaults

### DIFF
--- a/integration_test/test_xgboost_run.py
+++ b/integration_test/test_xgboost_run.py
@@ -222,9 +222,9 @@ class TestXGBoostRun(object):
       'log_checkpoints': False,
       'log_feature_importances': False,
       'log_metrics': False,
-      'log_params': False,
       'log_stderr': False,
       'log_stdout': False,
+      'log_xgboost_defaults': False,
     })
     ctx = sigopt.xgboost.run(**self.run_params)
     run = sigopt.get_run(ctx.run.id)
@@ -237,7 +237,8 @@ class TestXGBoostRun(object):
           self.run_params['evals'], self.run_params['params']['eval_metric']
         )
       }
-    assert not run.assignments
+    assert len(run.assignments) <= len(self.run_params['params']) + 1
+    self._verify_miscs_data_logging(run)
     assert not run.logs
     ctx.run.end()
 

--- a/integration_test/test_xgboost_run.py
+++ b/integration_test/test_xgboost_run.py
@@ -253,11 +253,13 @@ class TestXGBoostRun(object):
     del self.run_params['params']['eta']
     del self.run_params['params']['gamma']
     del self.run_params['params']['lambda']
+    del self.run_params['num_boost_round']
     ctx = sigopt.xgboost.run(**self.run_params)
     run = sigopt.get_run(ctx.run.id)
     assert numpy.isclose(run.assignments['eta'], 0.3)
     assert run.assignments['gamma'] == 0
     assert run.assignments['lambda'] == 1
+    assert run.assignments['num_boost_round'] == 10
 
   def test_provided_run(self):
     self.run_params = _form_random_run_params(task="binary")

--- a/sigopt/xgboost/run.py
+++ b/sigopt/xgboost/run.py
@@ -17,7 +17,7 @@ from .constants import (
   USER_SOURCE_NAME,
   XGBOOST_DEFAULTS_SOURCE_NAME,
 )
-from .utils import get_all_run_params
+from .utils import get_booster_params
 
 
 DEFAULT_RUN_OPTIONS = {
@@ -38,6 +38,8 @@ XGB_INTEGRATION_KEYWORD = '_IS_XGB_RUN'
 
 PARAMS_LOGGED_AS_METADATA = [
   'eval_metric',
+  'interaction_constraints'
+  'monotone_constraints',
   'objective',
   'updater',
 ]
@@ -175,7 +177,7 @@ class XGBRun:
     self.log_default_params()
 
   def log_default_params(self):
-    all_xgb_params = get_all_run_params(self.model, num_boost_round=self.num_boost_round, **self.params)
+    all_xgb_params = get_booster_params(self.model)
     reported_params = self.run.params.keys()
 
     xgb_default_params = {}

--- a/sigopt/xgboost/run.py
+++ b/sigopt/xgboost/run.py
@@ -140,6 +140,8 @@ class XGBRun:
         self.params.update(self.run.params)
         if 'num_boost_round' in self.params:
           self.num_boost_round = self.params.pop('num_boost_round')
+        if 'early_stopping_rounds' in self.params:
+          self.early_stopping_rounds = self.params.pop('early_stopping_rounds')
     elif self.run_options_parsed['name'] is not None:
       self.run = create_run(name=self.run_options_parsed['name'])
     else:
@@ -174,6 +176,9 @@ class XGBRun:
 
     if 'num_boost_round' not in self.run.params.keys():
       self._log_param_by_source('num_boost_round', self.num_boost_round, USER_SOURCE_NAME)
+
+    if self.early_stopping_rounds is not None and 'early_stopping_rounds' not in self.run.params.keys():
+      self._log_param_by_source('early_stopping_rounds', self.early_stopping_rounds, USER_SOURCE_NAME)
 
     if self.run_options_parsed['log_xgboost_defaults']:
       self.log_default_params()

--- a/sigopt/xgboost/run.py
+++ b/sigopt/xgboost/run.py
@@ -24,10 +24,10 @@ DEFAULT_RUN_OPTIONS = {
   'log_checkpoints': True,
   'log_feature_importances': True,
   'log_metrics': True,
-  'log_params': True,
   'log_stdout': True,
   'log_stderr': True,
   'log_sys_info': True,
+  'log_xgboost_defaults': True,
   'name': None,
   'run': None,
 }
@@ -174,7 +174,9 @@ class XGBRun:
 
     if 'num_boost_round' not in self.run.params.keys():
       self._log_param_by_source('num_boost_round', self.num_boost_round, USER_SOURCE_NAME)
-    self.log_default_params()
+
+    if self.run_options_parsed['log_xgboost_defaults']:
+      self.log_default_params()
 
   def log_default_params(self):
     all_xgb_params = get_booster_params(self.model)
@@ -328,8 +330,7 @@ def run(
   _run.form_callbacks()
   _run.train_xgb()
   _run.log_metadata()
-  if _run.run_options_parsed['log_params']:
-    _run.log_params()
+  _run.log_params()
   _run.check_learning_task()
   _run.log_training_metrics()
   _run.log_validation_metrics()

--- a/sigopt/xgboost/run.py
+++ b/sigopt/xgboost/run.py
@@ -38,7 +38,7 @@ XGB_INTEGRATION_KEYWORD = '_IS_XGB_RUN'
 
 PARAMS_LOGGED_AS_METADATA = [
   'eval_metric',
-  'interaction_constraints'
+  'interaction_constraints',
   'monotone_constraints',
   'objective',
   'updater',

--- a/sigopt/xgboost/utils.py
+++ b/sigopt/xgboost/utils.py
@@ -1,78 +1,36 @@
-import inspect
 import json
 
-from .compat import xgboost
-
-def get_default_args(func):
-  signature = inspect.signature(func)
-  return {
-    k: v.default
-    for k, v in signature.parameters.items() if v.default is not inspect.Parameter.empty
-  }
-
-TRAIN_PARAMETERS = ['num_boost_round', 'early_stopping_rounds']
-
-def get_train_defaults():
-  train_default_args = get_default_args(xgboost.train)
-  defaults = {k: train_default_args[k] for k in TRAIN_PARAMETERS}
-  return defaults
-
-def parse_parameter(value):
-  for t in (int, float, str):
-    try:
-      ret = t(value)
-      return ret
-    except ValueError:
-      continue
-  return str(value)
+from .compat import Booster
 
 
 def get_booster_params(booster):
   # refer:
-  # https://github.com/dmlc/xgboost/blob/406c70ba0e831babce4855d48793df6924e21cbf/python-package/xgboost/sklearn.py#L493
+  # https://github.com/dmlc/xgboost/blob/release_1.5.0/python-package/xgboost/sklearn.py#L522
 
-  '''Get xgboost specific parameters.'''
+  def parse_json_parameter_value(value):
+    for convert_type in (int, float, str):
+      try:
+        ret = convert_type(value)
+        return ret
+      except ValueError:
+        continue
+    return str(value)
+
+  assert isinstance(booster, Booster)
   config = json.loads(booster.save_config())
   stack = [config]
-  internal = {}
+  all_xgboost_params = {}
   while stack:
     obj = stack.pop()
     for k, v in obj.items():
       if k.endswith('_param'):
         for p_k, p_v in v.items():
-          internal[p_k] = p_v
+          all_xgboost_params[p_k] = p_v
       elif isinstance(v, dict):
         stack.append(v)
 
   params = {}
-  for k, v in internal.items():
-    params[k] = parse_parameter(v)
+  for k, v in all_xgboost_params.items():
+    params[k] = parse_json_parameter_value(v)
 
-  return params
-
-def get_train_params(**kwargs):
-  params = get_train_defaults()
-  for k, v in kwargs.items():
-    if k in TRAIN_PARAMETERS:
-      params[k] = v
-  return params
-
-
-def get_all_run_params(booster, **train_params):
-  """
-  Get all parameters of a run.
-
-  Parameters
-  ----------
-  booster : xgboost.Booster
-      Booster model.
-  train_kwargs:
-      Train args already set.
-
-  Returns
-  ----------
-      dict of run parameters
-  """
-  params = get_train_params(**train_params)
-  params.update(get_booster_params(booster))
   return params


### PR DESCRIPTION
Simplifying some of log default parameters logic.

* Always log `num_boost_round` as user specified.
* Remove option to set `log_params` in run_options.
* Add option `log_xgboost_defaults` to turn on/off xgboost default logging.