### PR TITLE
params overwriting

### DIFF
--- a/integration_test/test_xgboost_experiment.py
+++ b/integration_test/test_xgboost_experiment.py
@@ -131,7 +131,6 @@ class TestXGBoostExperiment:
     ctx = sigopt.xgboost.run(
       params=fixed_params,
       dtrain=run_params['dtrain'],
-      num_boost_round=run_params['num_boost_round'],
       evals=run_params['evals'],
       verbose_eval=False,
       run_options={'run': custom_run},
@@ -143,8 +142,8 @@ class TestXGBoostExperiment:
     assert run_obj.metadata['eval_metric'] == str(fixed_params['eval_metric'])
     assert run_obj.assignments['eta']  == custom_run.params['eta']
     assert run_obj.assignments['max_depth'] == custom_run.params['max_depth']
-    assert 0 < run_obj.values['test0-F1'].value < 1
-    assert 0 < run_obj.values['test0-recall'].value < 1
+    assert 0 <= run_obj.values['test0-F1'].value <= 1
+    assert 0 <= run_obj.values['test0-recall'].value <= 1
     assert run_obj.values['Training time'].value > 0
     ctx.run.end()
     assert not experiment.is_finished()

--- a/sigopt/xgboost/experiment.py
+++ b/sigopt/xgboost/experiment.py
@@ -116,11 +116,10 @@ class XGBExperiment:
           num_boost_round_run = run.params['num_boost_round']
         else:
           num_boost_round_run = DEFAULT_NUM_BOOST_ROUND
-        all_params = {**run.params, **self.params, 'num_boost_round': num_boost_round_run}
         self.run_options['run'] = run
 
         XGBRunWrapper(
-          all_params,
+          self.params,
           self.dtrain,
           num_boost_round=num_boost_round_run,
           evals=self.evals,


### PR DESCRIPTION
@ericlee0803 , I rearranged how the params are being passed around if `sigopt.xgboost.run` is created with a `run`. 
Now, it is more explicit that at the `train_model` stage, we need to merge all the params together, instead of before where I did it at the `create_run` stage.

Let me know if you think this makes more sense. 