### PR TITLE
Revive keepalive

### DIFF
--- a/sigopt/interface.py
+++ b/sigopt/interface.py
@@ -41,7 +41,6 @@ def get_expiring_session():
   session = requests.Session()
   session.mount("http://", adapter)
   session.mount("https://", adapter)
-  session.mount("http://", adapter)
   return session
 
 class ConnectionImpl(object):

--- a/sigopt/urllib3_patch.py
+++ b/sigopt/urllib3_patch.py
@@ -10,6 +10,7 @@ class SigOptHTTPConnection(HTTPConnection):
   """
   Tracks the time since the last activity of the connection.
   """
+
   def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)
     self.reset_activity()

--- a/sigopt/urllib3_patch.py
+++ b/sigopt/urllib3_patch.py
@@ -1,0 +1,54 @@
+import logging
+import time
+
+from urllib3.connection import HTTPConnection, HTTPSConnection
+from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
+
+logger = logging.getLogger("sigopt.urllib3_patch")
+
+class SigOptHTTPConnection(HTTPConnection):
+  """
+  Tracks the time since the last activity of the connection.
+  """
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    self.reset_activity()
+
+  def reset_activity(self):
+    self.last_activity = time.time()
+
+  def request(self, *args, **kwargs):
+    super().request(*args, **kwargs)
+    self.reset_activity()
+
+  def request_chunked(self, *args, **kwargs):
+    super().request_chunked(*args, **kwargs)
+    self.reset_activity()
+
+  def close(self, *args, **kwargs):
+    suoer().close()
+    self.reset_activity()
+
+class SigOptHTTPSConnection(SigOptHTTPConnection, HTTPSConnection):
+  pass
+
+class ExpiringHTTPConnectionPool(HTTPConnectionPool):
+  """
+  Returns a new connection when the time since the connection was last used is greater than the expiration time.
+  """
+
+  ConnectionCls = SigOptHTTPConnection
+
+  def __init__(self, *args, expiration_seconds=30, **kwargs):
+    super().__init__(*args, **kwargs)
+    self.expiration_seconds = expiration_seconds
+
+  def _get_conn(self, timeout=None):
+    conn = super()._get_conn(timeout=timeout)
+    if time.time() - conn.last_activity > self.expiration_seconds:
+      logger.debug("Abandoning expired connection")
+      return self._new_conn()
+    return conn
+
+class ExpiringHTTPSConnectionPool(ExpiringHTTPConnectionPool, HTTPSConnectionPool):
+  ConnectionCls = SigOptHTTPSConnection

--- a/sigopt/urllib3_patch.py
+++ b/sigopt/urllib3_patch.py
@@ -26,7 +26,7 @@ class SigOptHTTPConnection(HTTPConnection):
     self.reset_activity()
 
   def close(self, *args, **kwargs):
-    suoer().close()
+    super().close()
     self.reset_activity()
 
 class SigOptHTTPSConnection(SigOptHTTPConnection, HTTPSConnection):

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -17,7 +17,6 @@ class TestInterface(object):
     conn = Connection(client_token='client_token', _show_deprecation_warning=False)
     assert conn.impl.api_url == 'https://api.sigopt.com'
     assert conn.impl.requestor.verify_ssl_certs is None
-    assert conn.impl.requestor.session is None
     assert conn.impl.requestor.proxies is None
     assert conn.impl.requestor.timeout == DEFAULT_HTTP_TIMEOUT
     assert conn.impl.requestor.auth.username == 'client_token'

--- a/test/test_urllib3_patch.py
+++ b/test/test_urllib3_patch.py
@@ -1,0 +1,19 @@
+import pytest
+
+from sigopt.urllib3_patch import ExpiringHTTPConnectionPool, ExpiringHTTPSConnectionPool
+
+@pytest.mark.parametrize("pool_cls", [ExpiringHTTPConnectionPool, ExpiringHTTPSConnectionPool])
+def test_pool_reuses_connections(pool_cls):
+  pool = pool_cls(host="sigopt.com", expiration_seconds=30)
+  conn1 = pool._get_conn()
+  pool._put_conn(conn1)
+  conn2 = pool._get_conn()
+  assert conn1 is conn2
+
+@pytest.mark.parametrize("pool_cls", [ExpiringHTTPConnectionPool, ExpiringHTTPSConnectionPool])
+def test_pool_expires_connections(pool_cls):
+  pool = pool_cls(host="sigopt.com", expiration_seconds=0)
+  conn1 = pool._get_conn()
+  pool._put_conn(conn1)
+  conn2 = pool._get_conn()
+  assert conn1 is not conn2


### PR DESCRIPTION
This had previously been removed because the load balancer could send a RST packet while the client was closing the connection.

Our LBs don't send a `Keep-Alive` header to specify a timeout and it appears that cloudflare's proxy doesn't send this information either. In any event, `urllib3` and `requests` don't care and will leave a session open until the socket is closed via RST packet, which could happen simultaneously with a non-idempotent request.

This PR includes a patch to urllib3's classes to not keep a connection idle for more than 30s, which is at least lower than the idle timeout of our AWS LB.


## Testing 
See https://github.com/sigopt/sigopt-python/pull/122 for past performance, although note that that testing was done in the SF office and my testing today was done from NY.

**no keepalive**
```
In [4]: %timeit conn.experiments(544).fetch()
516 ms ± 151 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

**with keepalive**
```
In [3]: %timeit conn.experiments(544).fetch()
204 ms ± 45 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

This result is consistent with that other PR, showing about 2.5X difference.