### PR TITLE
Exponential backoff on rate limited requests

### DIFF
--- a/sigopt/requestor.py
+++ b/sigopt/requestor.py
@@ -1,3 +1,4 @@
+import backoff
 import requests
 
 from .compat import json as simplejson
@@ -82,6 +83,7 @@ class Requestor(object):
       backoff.expo,
       lambda response: response.status_code == HTTPStatus.TOO_MANY_REQUESTS,
       max_time=self.timeout,
+      jitter=backoff.full_jitter,
     )
     response = retry(self._request)(method, url, params, json, headers, user_agent)
     return self._handle_response(response)

--- a/sigopt/requestor.py
+++ b/sigopt/requestor.py
@@ -1,5 +1,6 @@
 import backoff
 import requests
+from http import HTTPStatus
 
 from .compat import json as simplejson
 from .config import config

--- a/sigopt/requestor.py
+++ b/sigopt/requestor.py
@@ -52,7 +52,6 @@ class Requestor(object):
   def delete(self, url, params=None, json=None, headers=None):
     return self.request('delete', url=url, params=params, json=json, headers=headers)
 
-
   def _request(self, method, url, params, json, headers, user_agent):
     headers = self._with_default_headers(headers, user_agent)
     try:


### PR DESCRIPTION
Tested with a stress test script, previously observed a bunch of 429 errors and now the script chuggs away without issue.