### PR TITLE
Don't auto create projects

### DIFF
--- a/sigopt/cli/commands/experiment/archive.py
+++ b/sigopt/cli/commands/experiment/archive.py
@@ -10,6 +10,7 @@ from ..base import archive_command
 def archive(project, experiment_ids):
   '''Archive SigOpt Experiments.'''
   factory = SigOptFactory(project)
+  factory.set_up_cli()
   for experiment_id in experiment_ids:
     try:
       factory.connection.experiments(experiment_id).delete()

--- a/sigopt/cli/commands/experiment/unarchive.py
+++ b/sigopt/cli/commands/experiment/unarchive.py
@@ -10,6 +10,7 @@ from ..base import unarchive_command
 def unarchive(project, experiment_ids):
   '''Unarchive SigOpt Experiments.'''
   factory = SigOptFactory(project)
+  factory.set_up_cli()
   for experiment_id in experiment_ids:
     try:
       factory.unarchive_experiment(experiment_id)

--- a/sigopt/cli/commands/local/run.py
+++ b/sigopt/cli/commands/local/run.py
@@ -17,5 +17,6 @@ from ..run_base import run_command
 def run(command, run_options, source_file, project):
   '''Create a SigOpt Run.'''
   factory = SigOptFactory(project)
+  factory.set_up_cli()
   with factory.create_run(name=run_options.get("name")) as run_context:
     run_user_program(config, run_context, command, source_file)

--- a/sigopt/cli/commands/local/start_worker.py
+++ b/sigopt/cli/commands/local/start_worker.py
@@ -19,6 +19,7 @@ from ..run_base import run_command
 def start_worker(experiment_id, command, run_options, source_file):
   '''Start a worker for the given Experiment.'''
   factory = SigOptFactory.from_default_project()
+  factory.set_up_cli()
   try:
     experiment = factory.get_experiment(experiment_id)
   except ValueError as ve:

--- a/sigopt/cli/commands/training_run/archive.py
+++ b/sigopt/cli/commands/training_run/archive.py
@@ -10,6 +10,7 @@ from ..base import archive_command
 def archive(project, run_ids):
   '''Archive SigOpt Runs.'''
   factory = SigOptFactory(project)
+  factory.set_up_cli()
   for run_id in run_ids:
     try:
       factory.archive_run(run_id)

--- a/sigopt/cli/commands/training_run/unarchive.py
+++ b/sigopt/cli/commands/training_run/unarchive.py
@@ -9,6 +9,7 @@ from ..base import unarchive_command
 def unarchive(project, run_ids):
   '''Unarchive SigOpt Runs.'''
   factory = SigOptFactory(project)
+  factory.set_up_cli()
   for run_id in run_ids:
     try:
       factory.unarchive_run(run_id)

--- a/sigopt/defaults.py
+++ b/sigopt/defaults.py
@@ -43,6 +43,6 @@ def ensure_project_exists(connection, project_id):
     connection.clients(client_id).projects(project_id).fetch()
   except ApiException as e:
     if e.status_code == http.HTTPStatus.NOT_FOUND:
-      raise ProjectNotFoundException(project_id)
+      raise ProjectNotFoundException(project_id) from e
     raise
   return client_id

--- a/sigopt/defaults.py
+++ b/sigopt/defaults.py
@@ -3,7 +3,7 @@ import http
 import re
 import os
 
-from .exception import ApiException
+from .exception import ApiException, ProjectNotFoundException
 
 INVALID_PROJECT_ID_STRING_CHARACTERS = re.compile(r'[^a-z0-9\-_\.]')
 VALID_PROJECT_ID = re.compile(r'[a-z0-9\-_\.]+\Z')
@@ -40,8 +40,9 @@ def get_default_name(project):
 def ensure_project_exists(connection, project_id):
   client_id = connection.tokens('self').fetch().client
   try:
-    connection.clients(client_id).projects().create(id=project_id, name=project_id)
+    connection.clients(client_id).projects(project_id).fetch()
   except ApiException as e:
-    if e.status_code != http.HTTPStatus.CONFLICT:
-      raise
+    if e.status_code == http.HTTPStatus.NOT_FOUND:
+      raise ProjectNotFoundException(project_id)
+    raise
   return client_id

--- a/sigopt/exception.py
+++ b/sigopt/exception.py
@@ -49,7 +49,7 @@ class RunException(SigOptException):
 class ProjectNotFoundException(SigOptException):
   def __init__(self, project_id):
     super().__init__(
-      f"The project {project_id} does not exist.\n"
+      f"The project '{project_id}' does not exist.\n"
       "Try any of the following steps to resolve this:\n"
       f"  * create a project with the ID '{project_id}' by visiting\n"
       "    https://app.sigopt.com/projects\n"

--- a/sigopt/exception.py
+++ b/sigopt/exception.py
@@ -51,10 +51,11 @@ class ProjectNotFoundException(SigOptException):
     super().__init__(
       f"The project {project_id} does not exist.\n"
       "Try any of the following steps to resolve this:\n"
-      f"  * create a project with the id '{project_id}' by visiting\n"
+      f"  * create a project with the ID '{project_id}' by visiting\n"
       "    https://app.sigopt.com/projects\n"
-      "  * change the project id by setting the SIGOPT_PROJECT environment variable or\n"
+      "  * change the project ID by setting the SIGOPT_PROJECT environment variable or\n"
       "    by renaming the current directory\n"
-      f"  * (advanced) change to a team that has the project '{project_id}' then find your\n"
-      "    API token for that team at https://app.sigopt.com/tokens/info"
+      f"  * (advanced) if the project you want to use is in a different team,\n"
+      "    change your API token by switching to that team and then going to\n"
+      "    https://app.sigopt.com/tokens/info"
     )

--- a/sigopt/exception.py
+++ b/sigopt/exception.py
@@ -45,3 +45,16 @@ class ApiException(SigOptException):
 
 class RunException(SigOptException):
   pass
+
+class ProjectNotFoundException(SigOptException):
+  def __init__(self, project_id):
+    super().__init__(
+      f"The project {project_id} does not exist.\n"
+      "Try any of the following steps to resolve this:\n"
+      f"  * create a project with the id '{project_id}' by visiting\n"
+      "    https://app.sigopt.com/projects\n"
+      "  * change the project id by setting the SIGOPT_PROJECT environment variable or\n"
+      "    by renaming the current directory\n"
+      f"  * (advanced) change to a team that has the project '{project_id}' then find your\n"
+      "    API token for that team at https://app.sigopt.com/tokens/info"
+    )

--- a/sigopt/factory.py
+++ b/sigopt/factory.py
@@ -1,9 +1,12 @@
+import click
+
 from sigopt.validate import validate_experiment_input
 
 from .defaults import check_valid_project_id, ensure_project_exists, get_default_project
 from .interface import get_connection
 from .sigopt_logging import print_logger
 from .run_factory import BaseRunFactory
+from .exception import ProjectNotFoundException
 from .experiment_context import ExperimentContext
 from .validate.keys import PROJECT_KEY, RUNS_ONLY_KEY
 from .run_context import global_run_context
@@ -47,6 +50,12 @@ class SigOptFactory(BaseRunFactory):
       "Experiment created, view it on the SigOpt dashboard at https://app.sigopt.com/experiment/%s",
       experiment.id,
     )
+
+  def set_up_cli(self):
+    try:
+      self.ensure_project_exists()
+    except ProjectNotFoundException as pnfe:
+      raise click.ClickException(pnfe) from pnfe
 
   def ensure_project_exists(self):
     # if we have already ensured that the project exists then we can skip this step in the future

--- a/test/runs/test_factory.py
+++ b/test/runs/test_factory.py
@@ -37,7 +37,6 @@ class TestSigOptFactory(object):
   def test_create_context_with_name(self, factory, api_connection):
     run_context = factory.create_run(name='test context')
     assert run_context is not None
-    assert api_connection.clients().projects().create.call_args[1]['name'] == 'test-project'
     api_connection.clients().projects().training_runs().create.assert_called_once()
     assert api_connection.clients().projects().training_runs().create.call_args[1]['name'] == 'test context'
 


### PR DESCRIPTION
Putting training runs in the wrong projects seems to be a common issue. It can be caused by inferring the project ID from the name of the current directory and automatically creating a project with that ID. By removing the auto project creation the user must choose to create a new project or set the `SIGOPT_PROJECT` variable/rename the directory.