### PR TITLE
Create projects via the CLI and client

### DIFF
--- a/sigopt/__init__.py
+++ b/sigopt/__init__.py
@@ -24,6 +24,7 @@ config.set_context_entry(_global_run_context)
 _global_factory = SigOptFactory(get_default_project())
 create_run = _global_factory.create_run
 create_experiment = _global_factory.create_experiment
+create_project = _global_factory.create_project
 get_experiment = _global_factory.get_experiment
 archive_experiment = _global_factory.archive_experiment
 unarchive_experiment = _global_factory.unarchive_experiment

--- a/sigopt/cli/arguments/__init__.py
+++ b/sigopt/cli/arguments/__init__.py
@@ -6,7 +6,7 @@ from .experiment_file import experiment_file_option
 from .experiment_id import experiment_id_argument
 from .identifiers import identifiers_argument, identifiers_help
 from .load_yaml import load_yaml_callback
-from .project import project_option
+from .project import project_option, project_name_option
 from .provider import provider_option
 from .run_file import run_file_option
 from .source_file import source_file_option

--- a/sigopt/cli/arguments/project.py
+++ b/sigopt/cli/arguments/project.py
@@ -18,7 +18,20 @@ project_option = click.option(
   "--project",
   callback=validate_project_id_callback,
   help="""
-  Provide a project ID string to associate the experiment with a new or existing project.
-  If a project ID is not provided, the parent directory is the default project ID.
+  Provide the project ID.
+  Projects can be created at https://app.sigopt.com/projects or with the command `sigopt create project`.
+  If a project ID is not provided then the project ID is determined in the following order:
+  first from the SIGOPT_PROJECT environment variable, then by the name of the current directory.
   """,
+)
+
+def validate_project_name_callback(ctx, p, value):  # pylint: disable=unused-argument
+  if value is None:
+    return get_default_project()
+  return value
+
+project_name_option = click.option(
+  '--project-name',
+  callback=validate_project_name_callback,
+  help="The name of the project.",
 )

--- a/sigopt/cli/commands/__init__.py
+++ b/sigopt/cli/commands/__init__.py
@@ -3,6 +3,7 @@ import sigopt.cli.commands.config
 import sigopt.cli.commands.experiment
 import sigopt.cli.commands.init
 import sigopt.cli.commands.local
+import sigopt.cli.commands.project
 import sigopt.cli.commands.version
 import sigopt.cli.commands.training_run
 

--- a/sigopt/cli/commands/project/__init__.py
+++ b/sigopt/cli/commands/project/__init__.py
@@ -1,0 +1,1 @@
+import sigopt.cli.commands.project.create

--- a/sigopt/cli/commands/project/create.py
+++ b/sigopt/cli/commands/project/create.py
@@ -18,3 +18,5 @@ def create(project, project_name):
   except ConflictingProjectException as cpe:
     raise click.ClickException(cpe) from cpe
   print_logger.info("Project '%s' created.", project)
+  print_logger.info("To use this project, set the SIGOPT_PROJECT environment variable:")
+  print_logger.info("> export SIGOPT_PROJECT='%s'", project)

--- a/sigopt/cli/commands/project/create.py
+++ b/sigopt/cli/commands/project/create.py
@@ -1,0 +1,20 @@
+import click
+
+from sigopt.exception import ConflictingProjectException
+from sigopt.factory import SigOptFactory
+from sigopt.sigopt_logging import print_logger
+
+from ...arguments import project_option, project_name_option
+from ..base import create_command
+
+@create_command.command('project')
+@project_option
+@project_name_option
+def create(project, project_name):
+  '''Create a SigOpt Project.'''
+  factory = SigOptFactory(project)
+  try:
+    factory.create_project(project_name)
+  except ConflictingProjectException as cpe:
+    raise click.ClickException(cpe) from cpe
+  print_logger.info("Project '%s' created.", project)

--- a/sigopt/cli/commands/project/create.py
+++ b/sigopt/cli/commands/project/create.py
@@ -14,7 +14,7 @@ def create(project, project_name):
   '''Create a SigOpt Project.'''
   factory = SigOptFactory(project)
   try:
-    factory.create_project(project_name)
+    factory.create_project(name=project_name)
   except ConflictingProjectException as cpe:
     raise click.ClickException(cpe) from cpe
   print_logger.info("Project '%s' created.", project)

--- a/sigopt/defaults.py
+++ b/sigopt/defaults.py
@@ -44,7 +44,7 @@ def get_client_id(connection):
   return connection.tokens('self').fetch().client
 
 def ensure_project_exists(connection, project_id):
-  client_id = get_client_id()
+  client_id = get_client_id(connection)
   try:
     connection.clients(client_id).projects().create(id=project_id, name=project_id)
   except ApiException as e:

--- a/sigopt/defaults.py
+++ b/sigopt/defaults.py
@@ -14,7 +14,10 @@ def normalize_project_id(project_id):
 
 def check_valid_project_id(project_id):
   if not VALID_PROJECT_ID.match(project_id):
-    raise ValueError(f"project id is invalid: {project_id}")
+    raise ValueError(
+      f"Project ID is invalid: '{project_id}'\n"
+      "Project IDs can only consist of lowercase letters, digits, hyphens (-), underscores (_) and periods (.)."
+    )
 
 def get_default_project():
   project_id = os.environ.get('SIGOPT_PROJECT')

--- a/sigopt/defaults.py
+++ b/sigopt/defaults.py
@@ -37,8 +37,11 @@ def get_default_name(project):
   datetime_string = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
   return f'{project} {datetime_string}'
 
+def get_client_id(connection):
+  return connection.tokens('self').fetch().client
+
 def ensure_project_exists(connection, project_id):
-  client_id = connection.tokens('self').fetch().client
+  client_id = get_client_id()
   try:
     connection.clients(client_id).projects().create(id=project_id, name=project_id)
   except ApiException as e:

--- a/sigopt/exception.py
+++ b/sigopt/exception.py
@@ -45,3 +45,7 @@ class ApiException(SigOptException):
 
 class RunException(SigOptException):
   pass
+
+class ConflictingProjectException(SigOptException):
+  def __init__(self, project_id):
+    super().__init__(f"The project with id '{project_id}' already exists.")

--- a/sigopt/exception.py
+++ b/sigopt/exception.py
@@ -55,7 +55,8 @@ class ProjectNotFoundException(SigOptException):
     super().__init__(
       f"The project '{project_id}' does not exist.\n"
       "Try any of the following steps to resolve this:\n"
-      f"  * create a project with the ID '{project_id}' by visiting\n"
+      f"  * create a project with the ID '{project_id}' with the command\n"
+      f"    `sigopt create project --project '{project_id}'` or by visiting\n"
       "    https://app.sigopt.com/projects\n"
       "  * change the project ID by setting the SIGOPT_PROJECT environment variable or\n"
       "    by renaming the current directory\n"

--- a/sigopt/factory.py
+++ b/sigopt/factory.py
@@ -57,7 +57,7 @@ class SigOptFactory(BaseRunFactory):
       project = self.connection.clients(client_id).projects().create(id=self.project, name=project_name)
     except ApiException as e:
       if e.status_code == http.HTTPStatus.CONFLICT:
-        raise ConflictingProjectException(self.project)
+        raise ConflictingProjectException(self.project) from e
       raise
     self._client_id = client_id
     self._assume_project_exists = True

--- a/sigopt/factory.py
+++ b/sigopt/factory.py
@@ -51,10 +51,14 @@ class SigOptFactory(BaseRunFactory):
       experiment.id,
     )
 
-  def create_project(self, project_name):
+  def create_project(self, id_=None, name=None):
+    if id_ is not None:
+      self.set_project(id_)
+    if name is None:
+      name = self.project
     client_id = get_client_id(self.connection)
     try:
-      project = self.connection.clients(client_id).projects().create(id=self.project, name=project_name)
+      project = self.connection.clients(client_id).projects().create(id=self.project, name=name)
     except ApiException as e:
       if e.status_code == http.HTTPStatus.CONFLICT:
         raise ConflictingProjectException(self.project) from e


### PR DESCRIPTION
```
Usage: sigopt create project [OPTIONS]

  Create a SigOpt Project.

Options:
  -p, --project TEXT   Provide the project ID. Projects can be created at
                       https://app.sigopt.com/projects or with the command
                       `sigopt create project`. If a project ID is not
                       provided then the project ID is determined in the
                       following order: first from the SIGOPT_PROJECT
                       environment variable, then by the name of the current
                       directory.
  --project-name TEXT  The name of the project.
  --help               Show this message and exit.
```

```python
import sigopt
sigopt.create_project("optional-project-id", "Optional Project Name")
```