### PR TITLE
Version 8.6.1

### DIFF
--- a/sigopt/version.py
+++ b/sigopt/version.py
@@ -1,4 +1,4 @@
 # Copyright © 2022 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
-VERSION = '8.6.0'
+VERSION = '8.6.1'


### PR DESCRIPTION
# Changelog

  - use `aiexperiment` URLs where appropriate
  - copyright, license, inclusive language improvements