### PR TITLE
Patches for XGB integration

### DIFF
--- a/sigopt/xgboost/experiment.py
+++ b/sigopt/xgboost/experiment.py
@@ -110,7 +110,7 @@ class XGBExperiment:
       parameter_name = parameter['name']
       if 'bounds' not in parameter and PARAMETER_INFORMATION[parameter_name]['type'] in ['double', 'int']:
         if parameter_name not in SUPPORTED_AUTOBOUND_PARAMS:
-          raise ValueError(f'We do not support autoselection of bounds for {param_name}.')
+          raise ValueError(f'We do not support autoselection of bounds for {parameter_name}.')
         param_info = PARAMETER_INFORMATION[parameter_name]
         transformation = param_info['transformation'] if 'transformation' in param_info else None
         parameter.update(

--- a/sigopt/xgboost/experiment.py
+++ b/sigopt/xgboost/experiment.py
@@ -110,7 +110,7 @@ class XGBExperiment:
       parameter_name = parameter['name']
       if 'bounds' not in parameter and PARAMETER_INFORMATION[parameter_name]['type'] in ['double', 'int']:
         if parameter_name not in SUPPORTED_AUTOBOUND_PARAMS:
-          raise ValueError('We do not support autoselection of bounds for {param_name}.')
+          raise ValueError(f'We do not support autoselection of bounds for {param_name}.')
         param_info = PARAMETER_INFORMATION[parameter_name]
         transformation = param_info['transformation'] if 'transformation' in param_info else None
         parameter.update(

--- a/sigopt/xgboost/run.py
+++ b/sigopt/xgboost/run.py
@@ -233,7 +233,7 @@ class XGBRunHandler:
       sorted(scores.items(), key=lambda x:(x[1], x[0]), reverse=True)[:FEATURE_IMPORTANCES_MAX_NUM_FEATURE]
     )
 
-    if any(scoress.keys() > FEATURE_IMPORTANCES_MAX_KEY_CHARS):
+    if any(len(k) > FEATURE_IMPORTANCES_MAX_KEY_CHARS for k in scores.keys()):
       return
 
     fp = {

--- a/sigopt/xgboost/run.py
+++ b/sigopt/xgboost/run.py
@@ -94,11 +94,11 @@ def parse_run_options(run_options):
   return copy.deepcopy(DEFAULT_RUN_OPTIONS)
 
 
-def validate_xgboost_kwargs(**kwargs):
-  if kwargs:
-    for key in kwargs.keys():
+def validate_xgboost_kwargs(xgb_kwargs):
+  if xgb_kwargs:
+    for key in xgb_kwargs.keys():
       if key not in signature(xgboost.train).parameters.keys():
-        kwargs.pop("key")
+        xgb_kwargs.pop(key)
 
 
 class XGBRun(ModelAwareRun):

--- a/sigopt/xgboost/run.py
+++ b/sigopt/xgboost/run.py
@@ -38,6 +38,7 @@ DEFAULT_RUN_OPTIONS = {
 DEFAULT_CHECKPOINT_PERIOD = 5
 MAX_NUM_CHECKPOINTS = 200
 FEATURE_IMPORTANCES_MAX_NUM_FEATURE = 50
+FEATURE_IMPORTANCES_MAX_KEY_CHARS = 100
 XGB_INTEGRATION_KEYWORD = '_IS_XGB_RUN'
 
 PARAMS_LOGGED_AS_METADATA = [
@@ -231,6 +232,10 @@ class XGBRunHandler:
     scores = dict(
       sorted(scores.items(), key=lambda x:(x[1], x[0]), reverse=True)[:FEATURE_IMPORTANCES_MAX_NUM_FEATURE]
     )
+
+    if any(scoress.keys() > FEATURE_IMPORTANCES_MAX_KEY_CHARS):
+      return
+
     fp = {
       'type': importance_type,
       'scores': scores,

--- a/sigopt/xgboost/run.py
+++ b/sigopt/xgboost/run.py
@@ -7,6 +7,7 @@ import math
 import json
 import platform
 import time
+import warnings
 
 from .. import create_run
 from ..log_capture import SystemOutputStreamMonitor
@@ -98,6 +99,10 @@ def validate_xgboost_kwargs(xgb_kwargs):
   if xgb_kwargs:
     for key in list(xgb_kwargs.keys()):
       if key not in signature(xgboost.train).parameters.keys():
+        warnings.warn(
+          f"The argument `{key}` is not supported by this version of XGBoost, and has been ignored",
+          RuntimeWarning,
+        )
         xgb_kwargs.pop(key)
 
 

--- a/sigopt/xgboost/run.py
+++ b/sigopt/xgboost/run.py
@@ -96,7 +96,7 @@ def parse_run_options(run_options):
 
 def validate_xgboost_kwargs(xgb_kwargs):
   if xgb_kwargs:
-    for key in xgb_kwargs.keys():
+    for key in list(xgb_kwargs.keys()):
       if key not in signature(xgboost.train).parameters.keys():
         xgb_kwargs.pop(key)
 

--- a/sigopt/xgboost/run.py
+++ b/sigopt/xgboost/run.py
@@ -244,6 +244,11 @@ class XGBRunHandler:
     )
 
     if any(len(k) > FEATURE_IMPORTANCES_MAX_KEY_CHARS for k in scores.keys()):
+      warnings.warn(
+        f"Some of the feature names have more than {FEATURE_IMPORTANCES_MAX_KEY_CHARS} characters,"
+        " skipping logging feature importances."
+        RuntimeWarning,
+      )
       return
 
     fp = {

--- a/sigopt/xgboost/run.py
+++ b/sigopt/xgboost/run.py
@@ -84,7 +84,7 @@ def parse_run_options(run_options):
     if 'run' in run_options.keys() and run_options['run'] is not None:
       if not isinstance(run_options['run'], RunContext):
         raise TypeError(
-          "`run` must be an instance of RunContext object, not {type(run_options['run']).__name__}."
+          f"`run` must be an instance of RunContext object, not {type(run_options['run']).__name__}."
         )
 
     return {**DEFAULT_RUN_OPTIONS, **run_options}

--- a/sigopt/xgboost/run.py
+++ b/sigopt/xgboost/run.py
@@ -246,7 +246,7 @@ class XGBRunHandler:
     if any(len(k) > FEATURE_IMPORTANCES_MAX_KEY_CHARS for k in scores.keys()):
       warnings.warn(
         f"Some of the feature names have more than {FEATURE_IMPORTANCES_MAX_KEY_CHARS} characters,"
-        " skipping logging feature importances."
+        " skipping logging feature importances.",
         RuntimeWarning,
       )
       return

--- a/test/xgboost/test_run_options_parsing.py
+++ b/test/xgboost/test_run_options_parsing.py
@@ -7,8 +7,44 @@ import random
 
 from sigopt.objects import TrainingRun
 from sigopt.run_context import RunContext
-from sigopt.xgboost.run import DEFAULT_RUN_OPTIONS, parse_run_options
+from sigopt.xgboost.run import DEFAULT_RUN_OPTIONS, parse_run_options, XGBRunHandler
 
+class TestXGBoostKwargs(object):
+  def test_xgboost_kwargs_remove_wrong_key(self):
+    kwargs = {"WRONG_KEY": True}
+    xgb_run_handler = XGBRunHandler(
+      params={"max_depth": 2},
+      dtrain=Mock(),
+      num_boost_round=21,
+      evals=None,
+      early_stopping_rounds=10,
+      evals_result=None,
+      verbose_eval=True,
+      xgb_model=Mock(),
+      callbacks=None,
+      run_options=None,
+      **kwargs
+    )
+    assert not xgb_run_handler.kwargs
+
+  def test_xgboost_kwargs_keep_right_key(self):
+    kwargs = {"maximize": True}
+    xgb_run_handler = XGBRunHandler(
+      params={"max_depth": 2},
+      dtrain=Mock(),
+      num_boost_round=21,
+      evals=None,
+      early_stopping_rounds=None,
+      evals_result=None,
+      verbose_eval=True,
+      xgb_model=None,
+      callbacks=None,
+      run_options = {"autolog_metrics": True},
+      **kwargs
+    )
+    assert len(xgb_run_handler.kwargs) == 1
+    assert "maximize" in xgb_run_handler.kwargs
+    assert xgb_run_handler.kwargs["maximize"] == True
 
 class TestRunOptionsParsing(object):
   def test_run_options_wrong_type(self):

--- a/test/xgboost/test_run_options_parsing.py
+++ b/test/xgboost/test_run_options_parsing.py
@@ -8,7 +8,7 @@ import random
 from sigopt.objects import TrainingRun
 from sigopt.run_context import RunContext
 from sigopt.xgboost.run import DEFAULT_RUN_OPTIONS, parse_run_options, XGBRunHandler
-from .utils import ObserveWarnings
+from ..utils import ObserveWarnings
 
 class TestXGBoostKwargs(object):
   def test_xgboost_kwargs_remove_wrong_key(self):

--- a/test/xgboost/test_run_options_parsing.py
+++ b/test/xgboost/test_run_options_parsing.py
@@ -16,7 +16,7 @@ class TestXGBoostKwargs(object):
       "WRONG_KEY_1": True,
       "WRONG_KEY_2": 3.14,
     }
-    with ObserveWarnings() as w:
+    with ObserveWarnings() as ws:
       xgb_run_handler = XGBRunHandler(
         params={"max_depth": 2},
         dtrain=Mock(),
@@ -31,11 +31,11 @@ class TestXGBoostKwargs(object):
         **kwargs
       )
       assert not xgb_run_handler.kwargs
-      assert len(w) == len(kwargs)
-      assert issubclass(w[-1].category, RuntimeWarning)
+      assert len(ws) == len(kwargs)
+      for w in ws:
+        assert issubclass(w.category, RuntimeWarning)
 
   def test_xgboost_kwargs_keep_right_key(self):
-    kwargs = {"maximize": True}
     xgb_run_handler = XGBRunHandler(
       params={"max_depth": 2},
       dtrain=Mock(),
@@ -46,8 +46,8 @@ class TestXGBoostKwargs(object):
       verbose_eval=True,
       xgb_model=None,
       callbacks=None,
-      run_options = {"autolog_metrics": True},
-      **kwargs
+      maximize=True,
+      run_options={"autolog_metrics": True},
     )
     assert len(xgb_run_handler.kwargs) == 1
     assert "maximize" in xgb_run_handler.kwargs

--- a/test/xgboost/test_run_options_parsing.py
+++ b/test/xgboost/test_run_options_parsing.py
@@ -8,24 +8,31 @@ import random
 from sigopt.objects import TrainingRun
 from sigopt.run_context import RunContext
 from sigopt.xgboost.run import DEFAULT_RUN_OPTIONS, parse_run_options, XGBRunHandler
+from .utils import ObserveWarnings
 
 class TestXGBoostKwargs(object):
   def test_xgboost_kwargs_remove_wrong_key(self):
-    kwargs = {"WRONG_KEY": True}
-    xgb_run_handler = XGBRunHandler(
-      params={"max_depth": 2},
-      dtrain=Mock(),
-      num_boost_round=21,
-      evals=None,
-      early_stopping_rounds=10,
-      evals_result=None,
-      verbose_eval=True,
-      xgb_model=Mock(),
-      callbacks=None,
-      run_options=None,
-      **kwargs
-    )
-    assert not xgb_run_handler.kwargs
+    kwargs = {
+      "WRONG_KEY_1": True,
+      "WRONG_KEY_2": 3.14,
+    }
+    with ObserveWarnings() as w:
+      xgb_run_handler = XGBRunHandler(
+        params={"max_depth": 2},
+        dtrain=Mock(),
+        num_boost_round=21,
+        evals=None,
+        early_stopping_rounds=10,
+        evals_result=None,
+        verbose_eval=True,
+        xgb_model=Mock(),
+        callbacks=None,
+        run_options=None,
+        **kwargs
+      )
+      assert not xgb_run_handler.kwargs
+      assert len(w) == len(kwargs)
+      assert issubclass(w[-1].category, RuntimeWarning)
 
   def test_xgboost_kwargs_keep_right_key(self):
     kwargs = {"maximize": True}


### PR DESCRIPTION
Some patches for xgboost integration based on recent feedback.

* Missing f-strings
* Skip uploading feature importances if feature_name has > 100 chars
* Using `**kwargs` to handle `xgboost.train` arguments that are not integrated to SigOpt. I think this will also allow us to support future versions of xgb (version > 1.5.x).