### PR TITLE
Unpin max version of xgboost

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ with open(os.path.join(here, 'requirements.txt')) as requirements_fp:
 with open(os.path.join(here, 'requirements-dev.txt')) as requirements_dev_fp:
   dev_install_requires = requirements_dev_fp.read().split('\n')
 
-xgboost_install_requires = ['xgboost>=1.3.1,<1.6.0', 'numpy>=1.15.0']
+xgboost_install_requires = ['xgboost>=1.3.1', 'numpy>=1.15.0']
 hyperopt_install_requires = ['hyperopt>=0.2.7']
 
 setup(


### PR DESCRIPTION
Now that we are passing non-integrated arguments via `**kwargs`, we could unpin the max version of XGBoost.