### PR TITLE
Lax pin on PyYAML

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ click>=8.0.0
 GitPython>=2.0.0
 packaging>=21.3
 pypng>=0.0.20
-PyYAML>=5.4.1,<6.0.0
+PyYAML>=5,<7
 requests>=2.25.0,<3.0.0
 urllib3>=1.26.5,<2.0.0


### PR DESCRIPTION
Hopefully helps users resolve this [issue](https://github.com/yaml/pyyaml/issues/601) by allowing them to pin PyYAML <= 5.3.1 or >= 6.0. The way we pinned >=5.4.1,<6 forces 5.4.1 to be installed which is not compatible with cython<3.0 in a way that is opaque to pip.