### PR TITLE
v8.8.2

### DIFF
--- a/sigopt/version.py
+++ b/sigopt/version.py
@@ -1,4 +1,4 @@
 # Copyright © 2022 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
-VERSION = "8.8.1"
+VERSION = "8.8.2"


### PR DESCRIPTION
# Changelog

 * Unpin `certifi` version for most recent certificates and better compatibility with other modules in the same environment