### PR TITLE
Bump urllib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ packaging>=21.3
 pypng>=0.0.20
 PyYAML>=5,<7
 requests>=2.25.0,<3.0.0
-urllib3>=1.26.5,<2.0.0
+urllib3>=2.5.0


### PR DESCRIPTION
This is to fix a security vuln with urllib <2.5, so we're going to bump. 
